### PR TITLE
Create and close stream even if it's empty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <name>splash</name>
 
   <properties>
@@ -19,10 +19,10 @@
     <spark.version>2.3.2</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.compat.version>2.11</scala.compat.version>
-    <jacoco.version>0.8.0</jacoco.version>
+    <jacoco.version>0.8.2</jacoco.version>
     <logback.version>1.2.3</logback.version>
     <guava.version>15.0</guava.version>
-    <test.runner.version>2.22.0</test.runner.version>
+    <test.runner.version>2.22.1</test.runner.version>
     <!-- run IT with the `integration-test` script -->
     <skipIT>true</skipIT>
   </properties>
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.10.0</version>
+      <version>3.11.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.2</version>
+      <version>1.18.4</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -205,8 +205,12 @@
             <phase>test</phase>
             <configuration>
               <property>
+                <name>usedefaultlisteners</name>
+                <value>false</value>
+              </property>
+              <property>
                 <name>listener</name>
-                <value>com.memverge.mvfs.LogListener</value>
+                <value>org.apache.spark.shuffle.LogListener</value>
               </property>
               <suiteXmlFiles>
                 <suiteXmlFile>src/test/resources/testng.xml

--- a/src/main/java/com/memverge/splash/TmpShuffleFile.java
+++ b/src/main/java/com/memverge/splash/TmpShuffleFile.java
@@ -56,6 +56,7 @@ public interface TmpShuffleFile extends ShuffleFile {
       throws IOException {
     final Logger log = LoggerFactory.getLogger(TmpShuffleFile.class);
     final OutputStream out = makeOutputStream(true);
+    log.info("merge {} files into {}.", srcFiles.size(), getId());
     final List<Long> lengths = srcFiles.stream().map(file -> {
       Long copied = null;
       try (final InputStream in = file.makeInputStream()) {

--- a/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
@@ -84,7 +84,6 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
         (0 until numPartitions).foreach(i => {
           val writer = partitionWriters(i)
           partitionTmpWrites(i) = writer.file
-          writer.commitAndGet()
           writer.close()
         })
 
@@ -138,8 +137,8 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
           try {
             partitionWriters.foreach(writer => {
               val file = writer.revertPartialWritesAndClose()
-              if (!file.delete()) {
-                logError(s"Error while deleting file ${file.getId}")
+              if (file.exists() && !file.delete()) {
+                logWarning(s"Error while deleting file ${file.getId}")
               }
             })
           } finally {

--- a/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
@@ -56,7 +56,7 @@ private[spark] class SplashObjectWriter(
 
   private var initialized = false
 
-  private lazy val mcs: ManualCloseOutputStream = initialize()
+  private val mcs: ManualCloseOutputStream = initialize()
   private var countOs: CountingOutputStream = _
   private var bufferedOs: OutputStream = _
   private var objOs: SerializationStream = _

--- a/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 
 import scala.util.control.NonFatal
 
-private[spark] object SplashUtils {
+private[spark] object SplashUtils extends Logging {
   def withResources[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
     val resource: T = r
     require(resource != null, "resource is null")
@@ -36,6 +36,9 @@ private[spark] object SplashUtils {
     } catch {
       case NonFatal(e) =>
         exception = e
+        throw e
+      case e: Throwable =>
+        logError("fatal error received.", e)
         throw e
     } finally {
       closeAndAddSuppressed(exception, resource)

--- a/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleUtil.scala
+++ b/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleUtil.scala
@@ -89,9 +89,13 @@ object LocalShuffleUtil extends Logging {
       blockManager.putBytes(blockId,
         new ChunkedByteBuffer(Array[ByteBuffer](mappedBuffer)),
         StorageLevel.DISK_ONLY)
-      mappedBuffer.asInstanceOf[DirectBuffer].cleaner().clean()
       channel.close()
-      logInfo(s"delete $tgtId to make space for the real file.")
+      val cleaner = mappedBuffer.asInstanceOf[DirectBuffer].cleaner()
+      if (cleaner != null) {
+        logDebug(s"release direct buffer of ${tmpFile.getAbsolutePath}")
+        cleaner.clean()
+      }
+      logDebug(s"remove tmp file ${tmpFile.getAbsolutePath}")
       FileUtils.deleteQuietly(tmpFile)
     }
   }

--- a/src/main/scala/org/apache/spark/shuffle/local/LocalTmpShuffleFile.scala
+++ b/src/main/scala/org/apache/spark/shuffle/local/LocalTmpShuffleFile.scala
@@ -86,7 +86,7 @@ class LocalTmpShuffleFile extends TmpShuffleFile with Logging {
     }
     if (commitTarget.exists()) {
       logWarning(s"commit target already exists, remove '${commitTarget.getId}'.")
-      commitTarget.delete()
+      commitTarget.file.delete()
     }
     logDebug(s"commit tmp file $getId to target file ${getCommitTarget.getId}.")
 

--- a/src/test/resources/integration.xml
+++ b/src/test/resources/integration.xml
@@ -4,6 +4,10 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="integration test" verbose="1">
+  <listeners>
+    <listener class-name="org.apache.spark.shuffle.LogListener"/>
+  </listeners>
+
   <test name="Splash integration test">
     <groups>
       <run>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -4,6 +4,10 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="unit test" verbose="1">
+  <listeners>
+    <listener class-name="org.apache.spark.shuffle.LogListener"/>
+  </listeners>
+
   <test name="Splash unit test">
     <groups>
       <run>

--- a/src/test/scala/org/apache/spark/shuffle/LogListener.scala
+++ b/src/test/scala/org/apache/spark/shuffle/LogListener.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 MemVerge Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.spark.internal.Logging
+import org.testng.{ITestResult, TestListenerAdapter}
+
+class LogListener extends TestListenerAdapter with Logging {
+  override def onTestStart(tr: ITestResult): Unit = {
+    super.onTestStart(tr)
+    logInfo(s"--- ${tr.getName}${getParams(tr)} --- test start.")
+  }
+
+  override def onTestFailure(tr: ITestResult): Unit = {
+    logError(s"--- ${tr.getName}${getParams(tr)} --- failed, took ${getSeconds(tr)}s.")
+    val params = tr.getParameters
+    if (params.nonEmpty) {
+      logError(s"test parameters: $params.")
+    }
+    logError("detail:", tr.getThrowable)
+  }
+
+  override def onTestSkipped(tr: ITestResult): Unit = {
+    logWarning(s"--- ${tr.getName}${getParams(tr)} --- skipped, took ${getSeconds(tr)}s.")
+  }
+
+  override def onTestSuccess(tr: ITestResult): Unit = {
+    logInfo(s"--- ${tr.getName}${getParams(tr)} --- passed, took ${getSeconds(tr)}s.")
+  }
+
+  private def getParams(tr: ITestResult): String = {
+    val params = tr.getParameters
+    if (params.nonEmpty) {
+      s" [${StringUtils.join(params, ", ")}]"
+    } else {
+      ""
+    }
+  }
+
+  private def getSeconds(tr: ITestResult) = (tr.getEndMillis - tr.getStartMillis).toDouble / 1000
+}

--- a/src/test/scala/org/apache/spark/shuffle/SplashObjectWriterTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashObjectWriterTest.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 import com.memverge.splash.{StorageFactoryHolder, TmpShuffleFile}
 import org.apache.spark.storage.ShuffleDataBlockId
 import org.assertj.core.api.Assertions.assertThat
-import org.testng.annotations.{AfterClass, Test}
+import org.testng.annotations.{AfterClass, AfterMethod, Test}
 
 @Test(groups = Array("UnitTest", "IntegrationTest"))
 class SplashObjectWriterTest {
@@ -30,6 +30,13 @@ class SplashObjectWriterTest {
   @AfterClass
   def afterClass(): Unit = {
     StorageFactoryHolder.getFactory.reset()
+  }
+
+  @AfterMethod
+  def afterMethod(): Unit = {
+    if (objWriter != null) {
+      objWriter.close()
+    }
   }
 
   def testCommitWithoutInitialize(): Unit = {

--- a/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
+++ b/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
@@ -80,6 +80,7 @@ object TestUtil {
       .set("spark.shuffle.spill.batchSize", "10")
       .set("spark.shuffle.spill.initialMemoryThreshold", "512")
       .set("spark.shuffle.sort.bypassMergeThreshold", "0")
+      .set("splash.local.internal.alwaysRemote", "false")
 
   def newBaseShuffleConf: SparkConf = newSparkConf()
       .set("spark.shuffle.mvfs.useBaseShuffle", "true")


### PR DESCRIPTION
Remove the `lazy` descriptor of output stream in `SplashObjectWriter`.
That means we will create output stream as soon as the writer object is
created.  It helps us to better manager the file resource and make sure
each output file is closed properly.

Other changes:
* Add log listener to print test information in log.