### PR TITLE
[GH-6] Do not clean shuffle data on executor failure.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.11.1</version>
+      <version>3.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleFile.scala
+++ b/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleFile.scala
@@ -70,7 +70,7 @@ class LocalShuffleFile(path: String)
   override def getId: String = file.getAbsolutePath
 
   private def useRemote =
-    SparkEnv.get.conf.get(LocalOpts.alwaysUseRemote.key).toBoolean
+    SparkEnv.get.conf.get(LocalOpts.alwaysUseRemote.key, "false").toBoolean
 
   override def makeInputStream(): InputStream = {
     if (!useRemote && isLocal) {


### PR DESCRIPTION
Shuffle manager cleans up the application folder when it receives `stop`
call.  It causes problem if this shuffle manager lives in an failed executor.
Because other executors are still using the data.

Update the logic to check the role of current process before clearing
the shuffle data or application data.  Only driver can clean the data.
Since each application has only driver, we could make sure that those
data are no longer needed.

Also fix an issue in `StorageFactoryHolder` that `SparkConf` is updated
recursively and is always null during the initialization of
`StorageFactory`.

This fixes #6 .