### PR TITLE
Index/Data file not found error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <name>splash</name>
 
   <properties>

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
@@ -143,4 +143,19 @@ class SplashShuffleBlockResolverTest {
     val actual = resolver.checkIndexAndDataFile(shuffleId, mapId)
     assertThat(actual) isNull()
   }
+
+  def testCommitEmptyShuffleIndex(): Unit = {
+    val lengths = Array[Long]()
+    val mapId = 6
+    val dataTmp = resolver.getDataTmpFile(shuffleId, mapId)
+
+    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths, dataTmp)
+    val dataFile = resolver.getDataFile(shuffleId, mapId)
+    val indexFile = resolver.getIndexFile(shuffleId, mapId)
+    assertThat(dataFile.exists()) isTrue()
+    assertThat(dataFile.getSize) isEqualTo 0
+    assertThat(dataTmp.exists()) isFalse()
+    assertThat(indexFile.exists()) isTrue()
+    assertThat(indexFile.getSize) isEqualTo 0
+  }
 }

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleWriterTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleWriterTest.scala
@@ -32,7 +32,7 @@ class SplashShuffleWriterTest {
   private val resolver = new SplashShuffleBlockResolver(appId)
   private val reducerNum = 7
   private val mapId = 1
-  private val storageFactory = StorageFactoryHolder.getFactory
+  private lazy val storageFactory = StorageFactoryHolder.getFactory
 
   private var sc: SparkContext = _
   private var shuffleId = 0

--- a/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriterTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriterTest.scala
@@ -35,21 +35,21 @@ import scala.collection.mutable.ArrayBuffer
 class SplashUnsafeShuffleWriterTest {
   private val appId = "test-shuffle-unsafe-writer-app"
   private var sc: SparkContext = _
-  private val resolver = new SplashShuffleBlockResolver(appId)
+  private lazy val resolver = new SplashShuffleBlockResolver(appId)
   private val reducerNum = 4
   private val hashPartitioner = new HashPartitioner(reducerNum)
   private val mapId = 1
   private var shuffleId = 0
-  private val storageFactory = StorageFactoryHolder.getFactory
+  private lazy val storageFactory = StorageFactoryHolder.getFactory
 
   private var taskContext: TaskContext = _
   private var serializer: Serializer = _
 
   @BeforeClass
   def beforeClass(): Unit = {
-    storageFactory.reset()
     sc = TestUtil.newSparkContext(TestUtil.newSparkConf()
         .set("spark.serializer", classOf[KryoSerializer].getName))
+    storageFactory.reset()
   }
 
   @AfterClass


### PR DESCRIPTION
If the partition is empty, `TmpShuffleFile` may report a `file is
already committed` error.
The root cause of this issue is that the file is only created during
first write.
Add extra logic to check whether index/data tmp file is available when
we have nothing to write.  Create the tmp file so that they could be
committed in later stage.