### PR TITLE
[GH-13] Compatible changes for Spark 2.1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 language: java
+script:
+  - mvn package -Dspark.version=${SPARK}
+env:
+  matrix:
+    - SPARK=2.3.2
+    - SPARK=2.1.0
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+notifications:
+  email:
+    - cedric.zhuang@memverge.com
+    - yue.li@memverge.com
+    - sheperd.huang@memverge.com
+    - haiyan.wang@memverge.com

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.4</version>
+  <version>0.2.5</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/java/com/memverge/splash/TmpShuffleFile.java
+++ b/src/main/java/com/memverge/splash/TmpShuffleFile.java
@@ -36,6 +36,11 @@ public interface TmpShuffleFile extends ShuffleFile {
 
   ShuffleFile getCommitTarget();
 
+  /**
+   * Commit the tmp file to the target file.
+   * The implementation of this method must be atomic.
+   * If the commit target already exists, it should be removed.
+   */
   ShuffleFile commit() throws IOException;
 
   void recall();

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
@@ -228,12 +228,16 @@ private[spark] class SplashShuffleBlockResolver(
         val numOfLong = index.getSize / 8
         val offsets = 0L until numOfLong map { _ => in.readLong() }
 
-        // calculate lengths from offsets
-        val lengths = offsets zip offsets.tail map (i => i._2 - i._1)
-        // the size of data file should match with index file
-        // first element must be 0
-        if (offsets(0) == 0 && data.getSize == lengths.sum) {
-          ret = lengths.toArray
+        if (offsets.nonEmpty) {
+          // calculate lengths from offsets
+          val lengths = offsets zip offsets.tail map (i => i._2 - i._1)
+          // the size of data file should match with index file
+          // first element must be 0
+          if (offsets(0) == 0 && data.getSize == lengths.sum) {
+            ret = lengths.toArray
+          }
+        } else {
+          log.warn("offsets length is zero, {} is empty & corrupt.", index.getPath)
         }
       }
     }

--- a/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleFile.scala
+++ b/src/main/scala/org/apache/spark/shuffle/local/LocalShuffleFile.scala
@@ -45,10 +45,11 @@ class LocalShuffleFile(path: String)
     if (isLocal) {
       file.length()
     } else {
-      master.getLocationsAndStatus(blockId)
-          .map(status => status.status.diskSize)
-          .filter(size => size > 0)
-          .head
+      master.getBlockStatus(blockId).values
+          .filter(status => status.diskSize > 0 || status.memSize > 0)
+          .map(status => status.diskSize + status.memSize)
+          .headOption
+          .getOrElse(0L)
     }
   }
 

--- a/src/test/scala/org/apache/spark/shuffle/SplashOptsTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashOptsTest.scala
@@ -25,6 +25,17 @@ class SplashOptsTest {
   def testDefaultValues(): Unit = {
     assertThat(conf.get(SplashOpts.shuffleFileBufferKB)) isEqualTo 32
     assertThat(conf.get(SplashOpts.shuffleInitialBufferSize)) isEqualTo 4096
+    assertThat(conf.get(SplashOpts.storageFactoryName)) isNotEmpty()
+    assertThat(conf.get(SplashOpts.memoryMapThreshold)) isGreaterThan 0L
+    assertThat(conf.get(SplashOpts.localSplashFolder)) isNull()
+    assertThat(conf.get(SplashOpts.clearShuffleOutput)) isTrue()
+    assertThat(conf.get(SplashOpts.useRadixSort)) isTrue()
+    assertThat(conf.get(SplashOpts.shuffleCompress)) isTrue()
+  }
+
+  def testConfigsNotExistsInSpark210(): Unit = {
+    assertThat(conf.get(SplashOpts.shuffleFileBufferKB)) isEqualTo 32L
+    assertThat(conf.get(SplashOpts.forceSpillElements)) isEqualTo Integer.MAX_VALUE
   }
 
   def testSetValue(): Unit = {


### PR DESCRIPTION
As title.  Change some detail implementations to fix the compatibility
issues for Spark 2.1.0.

Enable matrix build for different Spark versions in travis.

This closes GH-13.