### PR TITLE
[GH-20] Deal with empty file in merge.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.6</version>
+  <version>0.2.7</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
@@ -33,7 +33,8 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
     resolver: SplashShuffleBlockResolver,
     handle: SplashBypassMergeSortShuffleHandle[K, V],
     mapId: Int,
-    taskContext: TaskContext) extends ShuffleWriter[K, V] with Logging {
+    taskContext: TaskContext,
+    noEmptyFile: Boolean = false) extends ShuffleWriter[K, V] with Logging {
 
   private val dep = handle.dependency
   private val partitioner = dep.partitioner
@@ -70,7 +71,8 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
           tmpDataFile,
           serializer,
           fileBufferSize,
-          writeMetrics)
+          writeMetrics,
+          noEmptyFile = noEmptyFile)
       })
 
       writeMetrics.incWriteTime(System.nanoTime() - start)


### PR DESCRIPTION
For some plugins, the output file is not created when there is no actual
write. We need to simulate the scenario and make sure the default
implementation of the merge function in `TmpShuffleFile` could deal with
it correctly. Zero should be returned to create a correct index file.

Add test case to simulate the situation when no file is available if the
partition length is zero.

This PR closes GH-20.