### PR TITLE
[GH-22] Adjust the location of `onApplicationStart`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.7</version>
+  <version>0.2.8</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/java/com/memverge/splash/StorageFactoryHolder.java
+++ b/src/main/java/com/memverge/splash/StorageFactoryHolder.java
@@ -63,6 +63,7 @@ public class StorageFactoryHolder {
   }
 
   public static void onApplicationStart() {
+    logger.info("call onApplicationStart of all splash shuffle listeners.");
     getListeners().forEach(ShuffleListener::onApplicationStart);
   }
 
@@ -75,6 +76,7 @@ public class StorageFactoryHolder {
   }
 
   public static void onApplicationEnd() {
+    logger.info("call onApplicationEnd of all splash shuffle listeners.");
     getListeners().forEach(ShuffleListener::onApplicationEnd);
   }
 

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
@@ -35,6 +35,7 @@ private[spark] class SplashShuffleBlockResolver(
     appId: String,
     fileBufferSizeKB: Int = 8)
     extends ShuffleBlockResolver with Logging {
+  StorageFactoryHolder.onApplicationStart()
 
   def getAppId: String = appId
 

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -32,8 +32,6 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
   StorageFactoryHolder.setSparkConf(conf)
   private val numMapsForShuffle = new ConcurrentHashMap[Int, Int]()
 
-  StorageFactoryHolder.onApplicationStart()
-
   /**
    * Return a resolver capable of retrieving shuffle block data based on block
    * coordinates.


### PR DESCRIPTION
Move `onApplicationStart` to `SplashShuffleBlockResolver`.  We can make
sure that spark conf instance is available at that time and allow
plugins to do proper configurations in this callback.

This PR closes GH-22.