### PR TITLE
[GH-24] Dump partition when read error happens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.8</version>
+  <version>0.2.9</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
@@ -20,8 +20,11 @@
  */
 package org.apache.spark.shuffle
 
+import java.io.File
+
 import com.memverge.splash.StorageFactoryHolder
 import org.apache.spark.SparkContext
+import org.apache.spark.storage.ShuffleBlockId
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations._
 
@@ -194,5 +197,15 @@ class SplashShuffleBlockResolverTest {
 
     val actual = resolver.checkIndexAndDataFile(shuffleId, mapId)
     assertThat(actual) isEqualTo indices
+  }
+
+  def testDumpFile(): Unit = {
+    val indices = Array(110L, 230L, 17L)
+    val total = indices.sum.intValue()
+    val mapId = 10
+
+    resolver.writeShuffle(shuffleId, mapId, indices, new Array[Byte](total))
+    val dumpFile = resolver.dump(ShuffleBlockId(shuffleId, mapId, 1))
+    assertThat(new File(dumpFile).length()) isEqualTo 230
   }
 }


### PR DESCRIPTION
Dump the current partition to a temp local folder to allow the developer to
diagnose the problem when a shuffle read error happens.

This would help the developer to diagnose problems like data corruption.

Make `dump` a utility function in the resolver and dump partition
whenever an exception is caught in `SplashShuffleFetcherIterator`.  Dump
files are named like `shuffle_0_1_2.dump`.

Add `dump` call in `SplashShuffleReader` to dump the partition if an error
happens in inserting records.

This closes GH-24.