### PR TITLE
Remove the file exists check.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.9</version>
+  <version>0.2.10</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
@@ -91,7 +91,7 @@ private[spark] class SplashObjectWriter(
       Utils.tryWithSafeFinally {
         closeOs()
         mcs.manualClose()
-        if (noEmptyFile && file.exists() && file.getSize == 0) {
+        if (noEmptyFile && committedPosition == 0) {
           file.recall()
         }
       } {

--- a/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorter.scala
@@ -64,7 +64,6 @@ private[spark] class SplashUnsafeSorter(
 
   private val storageFactory = StorageFactoryHolder.getFactory
 
-  private[this] val taskMemoryManager = context.taskMemoryManager()
   private val writeMetrics = context.taskMetrics().shuffleWriteMetrics
 
   private val initialSize: Int = conf.get(SplashOpts.shuffleInitialBufferSize)

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleBlockResolverTest.scala
@@ -23,6 +23,8 @@ package org.apache.spark.shuffle
 import java.io.File
 
 import com.memverge.splash.StorageFactoryHolder
+import org.apache.commons.io.FileUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.storage.ShuffleBlockId
 import org.assertj.core.api.Assertions.assertThat
@@ -33,6 +35,7 @@ import org.testng.annotations._
 class SplashShuffleBlockResolverTest {
   private var resolver: SplashShuffleBlockResolver = _
   private var sc: SparkContext = _
+  private var dumpFile: String = _
 
   @BeforeClass
   def beforeClass(): Unit = {
@@ -54,6 +57,9 @@ class SplashShuffleBlockResolverTest {
   @AfterMethod
   def afterMethod(): Unit = {
     StorageFactoryHolder.getFactory.reset()
+    if (StringUtils.isNotEmpty(dumpFile)) {
+      FileUtils.deleteQuietly(new File(dumpFile))
+    }
   }
 
   private val shuffleId = 1
@@ -205,7 +211,7 @@ class SplashShuffleBlockResolverTest {
     val mapId = 10
 
     resolver.writeShuffle(shuffleId, mapId, indices, new Array[Byte](total))
-    val dumpFile = resolver.dump(ShuffleBlockId(shuffleId, mapId, 1))
+    dumpFile = resolver.dump(ShuffleBlockId(shuffleId, mapId, 1))
     assertThat(new File(dumpFile).length()) isEqualTo 230
   }
 }


### PR DESCRIPTION
Remove multiple files exists check in the shuffle manager.  Instead, try
the operation and catch the exception if the file does not exist.  We hope
this could improve the performance on happy paths.

This commit also fixes the warning messages in the build.
This closes #16 