### PR TITLE
Write spill instead of partition data file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.10</version>
+  <version>0.2.11</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>


### PR DESCRIPTION
For the bypass merge sort shuffle code path, use the make spill file API
instead of the make shuffle data file API provided by the storage plugin
to avoid the file already exists error.