### PR TITLE
Enhance hash based shuffle (bypassMergeSort).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.2.10</version>
+  <version>0.3.0</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -49,15 +49,18 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
       numMaps: Int,
       dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
     if (shouldBypassMergeSort(dependency)) {
+      logInfo("apply SplashBypassMergeSortShuffleHandle")
       new SplashBypassMergeSortShuffleHandle[K, V](
         shuffleId, numMaps, dependency.asInstanceOf[ShuffleDependency[K, V, V]]
       )
     } else if (useSerializedShuffle(dependency)) {
       // Try to buffer map outputs in a serialized form, since this
       // is more efficient:
+      logInfo("apply SplashSerializedShuffleHandle")
       new SplashSerializedShuffleHandle[K, V](
         shuffleId, numMaps, dependency.asInstanceOf[ShuffleDependency[K, V, V]])
     } else {
+      logInfo("apply BaseShuffleHandle")
       // Buffer map outputs in a deserialized form:
       new BaseShuffleHandle(shuffleId, numMaps, dependency)
     }
@@ -182,6 +185,8 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
       false
     } else {
       val bypassMergeThreshold: Int = conf.get(SplashOpts.bypassSortThreshold)
+      logInfo(s"partitions ${dep.partitioner.numPartitions}, " +
+          s"bypass merge threshold $bypassMergeThreshold")
       dep.partitioner.numPartitions <= bypassMergeThreshold
     }
   }

--- a/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
+++ b/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
@@ -103,6 +103,9 @@ object TestUtil {
       .set("spark.shuffle.sort.bypassMergeThreshold", "0")
       .set("splash.local.internal.alwaysRemote", "false")
 
+  def hashBasedConf(conf: SparkConf): SparkConf =
+    conf.set("spark.shuffle.sort.bypassMergeThreshold", "1000000")
+
   def newBaseShuffleConf: SparkConf = newSparkConf()
       .set("spark.shuffle.splash.useBaseShuffle", "true")
 


### PR DESCRIPTION
Note: this change updates the interface!

Your plugin won't compile if you implemented `TmpShuffleFile.merge`.

Enhance the code path of hash based shuffle.  Write each partition
into a separate file instead of merging them into one single file.

The old logic merges the partition files generated by the mapper to a
single mapper output.  It tooks an extra copy to complete this.  By
saving each partition into it's own file, we can eliminate this copy.