### PR TITLE
[GH-35] Print version during shuffle manager init.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>
@@ -345,6 +345,12 @@
         <version>3.7.1</version>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
 
   <reporting>

--- a/src/main/resources/splash.properties
+++ b/src/main/resources/splash.properties
@@ -1,0 +1,1 @@
+splash.version=${project.version}

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -20,6 +20,7 @@
  */
 package org.apache.spark.shuffle
 
+import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
 
 import com.memverge.splash.StorageFactoryHolder
@@ -29,6 +30,8 @@ import org.apache.spark.shuffle.sort.SortShuffleManager.MAX_SHUFFLE_OUTPUT_PARTI
 import org.apache.spark.shuffle.sort.SplashUnsafeShuffleWriter
 
 class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
+  logInfo(s"initialize SplashShuffleManager ${SplashShuffleManager.version}")
+
   StorageFactoryHolder.setSparkConf(conf)
   private val numMapsForShuffle = new ConcurrentHashMap[Int, Int]()
 
@@ -212,4 +215,13 @@ private[spark] class SplashBypassMergeSortShuffleHandle[K, V](
     numMaps: Int,
     dependency: ShuffleDependency[K, V, V])
     extends BaseShuffleHandle(shuffleId, numMaps, dependency) {
+}
+
+object SplashShuffleManager {
+  def version: String = {
+    val properties = new Properties()
+    properties.load(
+      getClass.getClassLoader.getResourceAsStream("splash.properties"))
+    properties.getProperty("splash.version")
+  }
 }

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Modifications copyright (C) 2018 MemVerge Inc.
+ *
+ * Replace the original shuffle class with Splash version classes.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+
+@Test(groups = Array("UnitTest"))
+class SplashShuffleManagerTest {
+  def testVersion(): Unit = {
+    val version = SplashShuffleManager.version
+    assertThat(version).matches("\\d+\\.\\d+\\.\\d+")
+  }
+}


### PR DESCRIPTION
Print the package version information in the log to make it easier
for the operator to track the jar version.

Add a companion object for `SplashShuffleManager` to hold the utility
function.

This closes GH-35.