### PR TITLE
[GH-37] Recuce the number of calls to getSize.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.1</version>
+  <version>0.5.2</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/ShuffleSpillInfo.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ShuffleSpillInfo.scala
@@ -27,4 +27,5 @@ case class ShuffleSpillInfo(
     partitionLengths: Array[Long],
     file: TmpShuffleFile,
     blockId: TempShuffleBlockId) {
+  lazy val spillSize:Long = partitionLengths.sum
 }

--- a/src/main/scala/org/apache/spark/shuffle/SpilledFile.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SpilledFile.scala
@@ -31,7 +31,7 @@ case class SpilledFile(
     serializerBatchSizes: Array[Long] = Array[Long](),
     elementsPerPartition: Array[Long] = Array[Long]()) extends Logging {
   if (success) {
-    logInfo(s"Spill success: ${file.getPath}, size: ${file.getSize}")
+    logDebug(s"Spill success: ${file.getPath}, size: ${file.getSize}")
   } else {
     logInfo(s"Spill failed: ${file.getPath}")
   }

--- a/src/main/scala/org/apache/spark/shuffle/SplashAppendOnlyMap.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashAppendOnlyMap.scala
@@ -365,7 +365,7 @@ private[spark] class SplashAppendOnlyMap[K, V, C](
         objectsWritten += 1
       }
       writer.close()
-      _bytesSpilled += spillTmpFile.getSize
+      _bytesSpilled += writer.committedPosition
       success = true
     } finally {
       if (!success || objectsWritten == 0) {

--- a/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
@@ -81,7 +81,7 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
           val file = writer.file
           writer.close()
           file.commit()
-          partitionLengths(i) = file.getCommitTarget.getSize
+          partitionLengths(i) = writer.committedPosition
         })
       } catch {
         case e: Exception =>

--- a/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashObjectWriter.scala
@@ -61,7 +61,7 @@ private[spark] class SplashObjectWriter(
   private var countOs: CountingOutputStream = _
   private var bufferedOs: OutputStream = _
   private var objOs: SerializationStream = _
-  private var committedPosition = 0L
+  private[shuffle] var committedPosition = 0L
 
   private var numRecordsWritten = 0
 

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleBlockResolver.scala
@@ -350,12 +350,11 @@ private[spark] class SplashShuffleBlockResolver(
   private def validateData(offsets: IndexedSeq[Long], data: ShuffleFile): Array[Long] = {
     var ret: Array[Long] = null
 
-    // calculate lengths from offsets
-    val lengths = offsets zip offsets.tail map (i => i._2 - i._1)
     // the size of data file should match with index file
     // first element must be 0
-    if (offsets(0) == 0 && data.getSize == lengths.sum) {
-      ret = lengths.toArray
+    if (offsets(0) == 0 && data.getSize == offsets.last) {
+      // calculate lengths from offsets
+      ret = (offsets zip offsets.tail map (i => i._2 - i._1)).toArray
 
       if (log.isDebugEnabled) {
         log.debug("log md5 for {} during shuffle write.", data.getPath)

--- a/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
@@ -100,7 +100,7 @@ class SplashSpillableIterator[T](var upstream: Iterator[T],
         val spilledFile = spillInMemoryIterator(upstream)
         val shuffleTmpFile = spilledFile.file
         nextUpstream = getNextUpstream(spilledFile)
-        logInfo(s"spilling in-memory " +
+        logDebug(s"spilling in-memory " +
             s"data structure to storage ${shuffleTmpFile.getPath} " +
             s"size ${shuffleTmpFile.getSize}.")
         spilledFileOpt = Some(spilledFile)

--- a/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriter.scala
@@ -199,8 +199,8 @@ private[spark] class SplashUnsafeShuffleWriter[K, V](
           logDebug("Using slow merge")
           partitionLengths = mergeSpillsWithStream(spills, dataTmp, Some(compressionCodec))
         }
-        writeMetrics.decBytesWritten(spills(spills.length - 1).file.getSize)
-        writeMetrics.incBytesWritten(dataTmp.getSize)
+        writeMetrics.decBytesWritten(spills(spills.length - 1).spillSize)
+        writeMetrics.incBytesWritten(partitionLengths.sum)
         partitionLengths
       }
     } catch {

--- a/src/test/scala/org/apache/spark/shuffle/SplashAppendOnlyMapTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashAppendOnlyMapTest.scala
@@ -265,6 +265,7 @@ class SplashAppendOnlyMapTest {
     val consumer = createMap[String]
     map.insertAll((1 to rddSize).iterator.map(_.toString).map(i => (i, i)))
     assertThat(map.spill(10000, consumer)) isGreaterThan 0L
+    assertThat(map.bytesSpilled) isEqualTo 8580L
     map.cleanupSpillFile()
     consumer.cleanupSpillFile()
   }


### PR DESCRIPTION
`ShuffleFile.getSize` is a meta-data call of the file system.  It could
take several microseconds or even milliseconds in a shared file system.
This would cause some overhead to the shuffle procedure.

Make several changes to reduce the calls to `getSize`:
* Downgrade the logs that tracks the file size to `DEBUG` so that
`getSize` is not invoked during production environment.
* Use the information available in memory to track the written size or
spilled size to reduce the call to `getSize`.

The `getSize` calls in the test files are not touched in this update.