### PR TITLE
[GH-39] Do not use `OutputStream.available()`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.2</version>
+  <version>0.5.3</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -74,6 +74,7 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
       handle: ShuffleHandle,
       mapId: Int,
       context: TaskContext): ShuffleWriter[K, V] = {
+    logDebug(s"get writer for shuffle ${handle.shuffleId} mapper $mapId.")
     numMapsForShuffle.putIfAbsent(
       handle.shuffleId,
       handle.asInstanceOf[BaseShuffleHandle[_, _, _]].numMaps)
@@ -109,6 +110,8 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
       startPartition: Int,
       endPartition: Int,
       context: TaskContext): ShuffleReader[K, C] = {
+    logDebug(s"get writer for shuffle ${handle.shuffleId} " +
+        s"partition $startPartition to $endPartition")
     new SplashShuffleReader(
       shuffleBlockResolver,
       handle.asInstanceOf[BaseShuffleHandle[K, _, C]],

--- a/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeShuffleWriter.scala
@@ -188,7 +188,10 @@ private[spark] class SplashUnsafeShuffleWriter[K, V](
       } else if (spills.length == 1) {
         // Here, we don't need to perform any metrics updates because the bytes written to this
         // output file would have already been counted as shuffle bytes written.
-        dataTmp.swap(spills(0).file)
+        val firstSpill = spills(0).file
+        logDebug(s"swap temp file, change ${firstSpill.uuid()}'s " +
+            s"target to ${dataTmp.getCommitTarget.getPath}")
+        dataTmp.swap(firstSpill)
         spills(0).partitionLengths
       } else {
         var partitionLengths: Array[Long] = null


### PR DESCRIPTION
We use `OutputStream.available()` to retrieve the partition size.  In
the implementation of `LimitedInputStream.available`, it always checks
the available size of the wrapped stream.  This behavior causes extra
calls to the `getSize` function.

During the calculation of the shuffle, the partition size or file size
is actually available in the memory.  Keep this information in the
function's return value so that other functions may use these lengths
instead of calling `OutputStream.available`.

This closes GH-39.