### PR TITLE
[GH-41] Create empty shuffle data file failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.3</version>
+  <version>0.5.4</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>


### PR DESCRIPTION
Consider this scenario, a previous task failed and didn't clean up the
temp file, the re-run task somehow create the temp file at the same
location.  This operation will fail due to the
`FileAlreadyExistsException`.  We need to delete and retry creation in
this scenario.

Add a create file retry and limit the retry number to avoid an infinite loop.

This closes GH-41.