### PR TITLE
[GH-43] Structure enhancement of the shuffle reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk8
 script:
   - mvn package -Dspark.version=${SPARK}
 env:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.6</version>
+  <version>0.6.0</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>
@@ -39,7 +39,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <hadoop.version>2.7.1</hadoop.version>
+    <hadoop.version>2.7.4</hadoop.version>
     <spark.version>2.3.2</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.compat.version>2.11</scala.compat.version>
@@ -296,7 +296,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>4.1.0</version>
         <executions>
           <execution>
             <id>scala-compile</id>
@@ -368,7 +368,6 @@
         <configuration>
           <targetJdk>1.8</targetJdk>
           <sourceEncoding>utf-8</sourceEncoding>
-          <linkXref>true</linkXref>
           <skipEmptyReport>false</skipEmptyReport>
           <targetJdk>${java.version}</targetJdk>
         </configuration>

--- a/src/main/java/com/memverge/splash/ManualCloseOutputStream.java
+++ b/src/main/java/com/memverge/splash/ManualCloseOutputStream.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash;
+
+import com.google.common.io.CountingOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.apache.spark.storage.TimeTrackingOutputStream;
+
+
+public class ManualCloseOutputStream extends OutputStream {
+
+  @SuppressWarnings("UnstableApiUsage")
+  private CountingOutputStream stream;
+
+  @SuppressWarnings("UnstableApiUsage")
+  ManualCloseOutputStream(OutputStream out, ShuffleWriteMetrics metrics) {
+    if (metrics != null) {
+      out = new TimeTrackingOutputStream(metrics, out);
+    }
+
+    stream = new CountingOutputStream(out);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    stream.write(b);
+  }
+
+  @Override
+  @SuppressWarnings("NullableProblems")
+  public void write(byte[] bytes) throws IOException {
+    stream.write(bytes);
+  }
+
+  public void write(String str) throws IOException {
+    stream.write(str.getBytes());
+  }
+
+  @Override
+  @SuppressWarnings("NullableProblems")
+  public void write(byte[] bytes, int off, int len) throws IOException {
+    stream.write(bytes, off, len);
+  }
+
+  @Override
+  public void flush() {
+  }
+
+  @Override
+  public void close() throws IOException {
+    stream.flush();
+  }
+
+  public long getCount() {
+    return stream.getCount();
+  }
+
+  public void manualClose() throws IOException {
+    stream.flush();
+    stream.close();
+  }
+}

--- a/src/main/java/com/memverge/splash/StorageFactory.java
+++ b/src/main/java/com/memverge/splash/StorageFactory.java
@@ -52,4 +52,8 @@ public interface StorageFactory {
 
   // cleanup
   void reset();
+
+  default int getFileBufferSize() {
+    return StorageFactoryHolder.getBufferSize();
+  }
 }

--- a/src/main/java/com/memverge/splash/StorageFactoryHolder.java
+++ b/src/main/java/com/memverge/splash/StorageFactoryHolder.java
@@ -34,6 +34,16 @@ public class StorageFactoryHolder {
     return INSTANCE.getRealFactory();
   }
 
+  public static void setBufferSize(int size) {
+    INSTANCE.bufferSize = size;
+  }
+
+  static int getBufferSize() {
+    return INSTANCE.bufferSize;
+  }
+
+  private int bufferSize = 32 * 1024;
+
   private SparkConf conf = null;
 
   public static void setSparkConf(SparkConf sparkConf) {

--- a/src/main/java/com/memverge/splash/TmpShuffleFile.java
+++ b/src/main/java/com/memverge/splash/TmpShuffleFile.java
@@ -15,9 +15,12 @@
  */
 package com.memverge.splash;
 
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.UUID;
+import org.apache.spark.executor.ShuffleWriteMetrics;
 
 public interface TmpShuffleFile extends ShuffleFile {
 
@@ -38,4 +41,23 @@ public interface TmpShuffleFile extends ShuffleFile {
   UUID uuid();
 
   OutputStream makeOutputStream();
+
+  default BufferedOutputStream makeBufferedOutputStream() {
+    return new BufferedOutputStream(
+        makeOutputStream(),
+        StorageFactoryHolder.getBufferSize());
+  }
+
+  default DataOutputStream makeBufferedDataOutputStream() {
+    return new DataOutputStream(makeBufferedOutputStream());
+  }
+
+  default ManualCloseOutputStream makeBufferedManualCloseOutputStream(
+      ShuffleWriteMetrics metrics) {
+    return new ManualCloseOutputStream(makeBufferedOutputStream(), metrics);
+  }
+
+  default ManualCloseOutputStream makeBufferedManualCloseOutputStream() {
+    return makeBufferedManualCloseOutputStream(null);
+  }
 }

--- a/src/main/scala/com/memverge/splash/BufferedIterator.scala
+++ b/src/main/scala/com/memverge/splash/BufferedIterator.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash
+
+import java.util.NoSuchElementException
+
+import scala.reflect.ClassTag
+
+
+case class BufferedIterator[T](
+    iterator: Iterator[T],
+    bufferSize: Int = 512)(implicit m: ClassTag[T]) extends Iterator[T] {
+  private var writeIndex: Int = 0
+  private val buffer = new Array[T](bufferSize)
+  private var readIndex: Int = 0
+
+  fill()
+
+  override def next(): T = {
+    if (readIndex == writeIndex && writeIndex < bufferSize) {
+      throw new NoSuchElementException("end of iterator")
+    }
+    val obj = buffer(readIndex)
+    readIndex += 1
+    if (readIndex == writeIndex) {
+      if (writeIndex == bufferSize) {
+        readIndex = 0
+        writeIndex = 0
+        fill()
+      }
+    }
+    obj
+  }
+
+  override def hasNext: Boolean = readIndex < writeIndex
+
+  def fill(): Unit = {
+    while (iterator.hasNext && writeIndex < bufferSize) {
+      val obj = iterator.next()
+      if (obj != null) {
+        buffer(writeIndex) = obj
+        writeIndex += 1
+      }
+    }
+  }
+
+  def bufferLastOpt(): Option[T] = {
+    if (writeIndex == 0) {
+      None
+    } else {
+      Some(buffer(writeIndex - 1))
+    }
+  }
+}
+

--- a/src/main/scala/org/apache/spark/shuffle/PairSpillReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/PairSpillReader.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import java.io.InputStream
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.DeserializationStream
+
+private class PairSpillReader[K, V](
+    spill: SpilledFile,
+    serializer: SplashSerializer)
+    extends Iterator[(K, V)] with Logging {
+  protected type KVPair = (K, V)
+  protected type KVIterator = Iterator[KVPair]
+
+  private var inputStream: InputStream = _
+  private var nextItem: KVPair = _
+
+  private val batchOffsets = spill.batchOffsets
+  private var startBatch = 0
+  private var endBatch = batchOffsets.length - 1
+
+  protected var keyValueIterator: KVIterator = nextBatchIterator()
+
+  protected def readNextItem(): KVPair = {
+    if (keyValueIterator == null) {
+      null
+    } else {
+      val pair = keyValueIterator.next()
+      if (!keyValueIterator.hasNext) {
+        keyValueIterator = nextBatchIterator()
+      }
+      pair
+    }
+  }
+
+  private def nextBatchStream(): DeserializationStream = {
+    if (startBatch < endBatch) {
+      close()
+
+      val start = batchOffsets(startBatch)
+      val end = batchOffsets(startBatch + 1)
+      startBatch += 1
+      logDebug(s"read batch $startBatch offset $start - $end from spill")
+
+      inputStream = spill.file.makeBufferedInputStreamWithin(start, end)
+      serializer.deserializeStream(spill.blockId, inputStream)
+    } else {
+      cleanup()
+      null
+    }
+  }
+
+  def limit(startBatch: Int, endBatch: Int): PairSpillReader[K, V] = {
+    this.startBatch = startBatch
+    this.endBatch = endBatch
+    try {
+      this.keyValueIterator = nextBatchIterator()
+    } catch {
+      case _: ArrayIndexOutOfBoundsException =>
+        // input batch index is not valid.
+        logWarning(s"$startBatch or $endBatch should be smaller " +
+            s"than ${batchOffsets.length}.  mark this iterator empty.")
+        this.keyValueIterator = null
+    }
+    this
+  }
+
+  def nextBatchIterator(): KVIterator = {
+    val stream = nextBatchStream()
+    if (stream != null) {
+      stream.asKeyValueIterator.asInstanceOf[KVIterator]
+    } else {
+      null
+    }
+  }
+
+  def cleanup(): Unit = {
+    startBatch = batchOffsets.length
+    close()
+  }
+
+  def close(): Unit = {
+    if (inputStream != null) {
+      inputStream.close()
+      inputStream = null
+    }
+  }
+
+  override def hasNext: Boolean = {
+    if (nextItem == null) {
+      nextItem = readNextItem()
+    }
+    nextItem != null
+  }
+
+  override def next(): KVPair = {
+    if (!hasNext) {
+      throw new NoSuchElementException
+    }
+    val item = nextItem
+    nextItem = null
+    item
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/PartitionedSpillReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/PartitionedSpillReader.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import org.apache.spark.internal.Logging
+
+private class PartitionedSpillReader[K, V](
+    spill: SpilledFile, serializer: SplashSerializer)
+    extends PairSpillReader(spill, serializer) with Logging {
+
+  private val numPartitions = spill.elementsPerPartition.length
+
+  private var partitionId = 0
+  private var indexInPartition = 0L
+  private var lastPartitionId = 0
+
+  skipToNextPartition()
+
+  private def skipToNextPartition(): Unit = {
+    while (partitionId < numPartitions &&
+        indexInPartition == spill.elementsPerPartition(partitionId)) {
+      partitionId += 1
+      indexInPartition = 0L
+    }
+  }
+
+  private def finished = partitionId == numPartitions
+
+  override protected def readNextItem(): KVPair = {
+    if (finished || keyValueIterator == null) {
+      null
+    } else {
+      val pair = keyValueIterator.next()
+      lastPartitionId = partitionId
+      if (!keyValueIterator.hasNext) {
+        keyValueIterator = nextBatchIterator()
+      }
+      indexInPartition += 1
+      skipToNextPartition()
+      pair
+    }
+  }
+
+  private var nextPartitionToRead = 0
+
+  def readNextPartition(): KVIterator = {
+    val reader = this
+    new KVIterator {
+      private val myPartition = nextPartitionToRead
+      nextPartitionToRead += 1
+
+      override def hasNext: Boolean = {
+        if (!reader.hasNext) return false
+        assert(lastPartitionId >= myPartition)
+        lastPartitionId == myPartition
+      }
+
+      override def next(): KVPair = reader.next()
+    }
+  }
+
+  def iterator(): Iterator[((Int, K), V)] =
+    map(kv => ((lastPartitionId, kv._1), kv._2))
+}

--- a/src/main/scala/org/apache/spark/shuffle/SpilledFile.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SpilledFile.scala
@@ -20,19 +20,132 @@
  */
 package org.apache.spark.shuffle
 
-import com.memverge.splash.TmpShuffleFile
+import com.memverge.splash.{StorageFactoryHolder, TmpShuffleFile}
 import org.apache.spark.internal.Logging
-import org.apache.spark.storage.BlockId
+import org.apache.spark.storage.{BlockId, TempLocalBlockId}
 
 case class SpilledFile(
     file: TmpShuffleFile,
-    blockId: BlockId,
-    success: Boolean,
-    serializerBatchSizes: Array[Long] = Array[Long](),
-    elementsPerPartition: Array[Long] = Array[Long]()) extends Logging {
-  if (success) {
-    logDebug(s"Spill success: ${file.getPath}, size: ${file.getSize}")
-  } else {
-    logInfo(s"Spill failed: ${file.getPath}")
+    batchOffsets: Array[Long] = Array[Long](),
+    elementsPerPartition: Array[Long] = Array[Long]()) {
+
+  val blockId: BlockId = SpilledFile.blockId(file)
+
+  lazy val bytesSpilled: Long =
+    batchOffsets.lastOption.getOrElse(file.getSize)
+
+  lazy val batchSizes: Array[Long] =
+    batchOffsets zip batchOffsets.tail map (i => i._2 - i._1)
+}
+
+
+object SpilledFile extends Logging {
+
+  // Size of object batches when reading/writing from serializers.
+  //
+  // Objects are written in batches, with each batch using its own serialization
+  // stream. This cuts down on the size of reference-tracking maps constructed
+  // when deserializing a stream.
+  //
+  // NOTE: Setting this too low can cause excessive copying when serializing,
+  // since some serializers grow internal data structures by growing + copying
+  // every time the number of objects doubles.
+  var serializeBatchSize = 10000L
+
+  private lazy val storageFactory = StorageFactoryHolder.getFactory
+
+  private def blockId(file: TmpShuffleFile): BlockId =
+    TempLocalBlockId(file.uuid())
+
+  def spill[K, V](
+      iterator: Iterator[(K, V)],
+      serializer: SplashSerializer): SpilledFile =
+    spill(WritablePairIterator(iterator), serializer)
+
+  def spill[K, V](iterator: WritableIterator[K, V],
+      serializer: SplashSerializer): SpilledFile = {
+    val file = storageFactory.makeSpillFile()
+    val writer = new SplashObjectWriter(
+      blockId(file),
+      file,
+      serializer)
+
+    var success = false
+    try {
+      while (iterator.hasNext) {
+        iterator.writeNext(writer)
+
+        if (writer.notCommittedRecords == serializeBatchSize) {
+          writer.commitAndGet()
+        }
+      }
+      success = true
+    } finally {
+      writer.close()
+      if (success) {
+        logDebug(s"Spill success: ${file.getPath}, size: ${file.getSize}")
+      } else {
+        logInfo(s"Spill failed: ${file.getPath}")
+      }
+
+      if (!success || writer.recordsWritten == 0) {
+        file.recall()
+      }
+    }
+
+    iterator.getSpill(file, writer.batchOffsets)
   }
+}
+
+
+trait WritableIterator[K, V] {
+  def writeNext(writer: SplashObjectWriter): Unit
+
+  def hasNext: Boolean
+
+  def getSpill(file: TmpShuffleFile, batchOffsets: Array[Long]): SpilledFile
+}
+
+
+private[spark] case class WritablePairIterator[K, V](
+    it: Iterator[(K, V)])
+    extends WritableIterator[K, V] {
+
+  override def writeNext(writer: SplashObjectWriter): Unit = {
+    writer.write(it.next)
+  }
+
+  override def hasNext: Boolean = it.hasNext
+
+  override def getSpill(
+      file: TmpShuffleFile, batchOffsets: Array[Long]): SpilledFile =
+    SpilledFile(file, batchOffsets)
+}
+
+
+private[spark] case class WritablePartitionedIterator[K, V](
+    it: Iterator[((Int, K), V)], numPartitions: Int)
+    extends WritableIterator[K, V] {
+
+  private[this] var cur = if (it.hasNext) it.next() else null
+
+  val elementsPerPartition = new Array[Long](numPartitions)
+
+  override def writeNext(writer: SplashObjectWriter): Unit = {
+    writer.write(key, value)
+    elementsPerPartition(partitionId) += 1
+    cur = if (it.hasNext) it.next() else null
+  }
+
+  override def hasNext: Boolean = cur != null
+
+  def partitionId: Int = cur._1._1
+
+  private def key: K = cur._1._2
+
+  private def value: V = cur._2
+
+  override def getSpill(
+      file: TmpShuffleFile, batchOffsets: Array[Long]): SpilledFile =
+    SpilledFile(file, batchOffsets, elementsPerPartition)
 }

--- a/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashBypassMergeSortShuffleWriter.scala
@@ -39,8 +39,6 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
   private val numPartitions = partitioner.numPartitions
   private val shuffleId = dep.shuffleId
   private val writeMetrics = taskContext.taskMetrics().shuffleWriteMetrics
-  private val conf = SparkEnv.get.conf
-  private val fileBufferSize = conf.get(SplashOpts.shuffleFileBufferKB).toInt * 1024
 
   private var partitionWriters: Array[SplashObjectWriter] = _
   private val partitionLengths: Array[Long] = Array.fill(numPartitions)(0L)
@@ -59,7 +57,6 @@ private[spark] class SplashBypassMergeSortShuffleWriter[K, V](
           blockId,
           tmpDataFile,
           serializer,
-          fileBufferSize,
           writeMetrics,
           noEmptyFile = noEmptyFile)
       })

--- a/src/main/scala/org/apache/spark/shuffle/SplashOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashOpts.scala
@@ -42,6 +42,11 @@ object SplashOpts {
         .booleanConf
         .createWithDefault(true)
 
+  lazy val spillCheckInterval: ConfigEntry[Int] =
+    createIfNotExists("spark.shuffle.spill.checkInterval", builder => {
+      builder.intConf.createWithDefault(1000)
+    })
+
   // spark options
   lazy val forceSpillElements: ConfigEntry[Int] =
     createIfNotExists("spark.shuffle.spill.numElementsForceSpillThreshold", builder => {
@@ -56,6 +61,11 @@ object SplashOpts {
   lazy val useRadixSort: ConfigEntry[Boolean] =
     createIfNotExists("spark.shuffle.sort.useRadixSort", builder => {
       builder.booleanConf.createWithDefault(true)
+    })
+
+  lazy val serializeBatchSize: ConfigEntry[Long] =
+    createIfNotExists("spark.shuffle.serialize.batchSize", builder => {
+      builder.longConf.createWithDefault(SpilledFile.serializeBatchSize)
     })
 
   lazy val fastMergeEnabled: ConfigEntry[Boolean] =
@@ -84,12 +94,12 @@ object SplashOpts {
   // compatible entries for spark 2.1, scala 2.10, migrated from spark 2.3
   lazy val shuffleFileBufferKB: ConfigEntry[Long] =
     createIfNotExists("spark.shuffle.file.buffer", builder => {
-    builder.doc("Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +
-        "otherwise specified. These buffers reduce the number of disk seeks and system calls " +
-        "made in creating intermediate shuffle files.")
-        .bytesConf(ByteUnit.KiB)
-        .createWithDefaultString("32k")
-  })
+      builder.doc("Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +
+          "otherwise specified. These buffers reduce the number of disk seeks and system calls " +
+          "made in creating intermediate shuffle files.")
+          .bytesConf(ByteUnit.KiB)
+          .createWithDefault(32)
+    })
 
   lazy val bypassSortThreshold: ConfigEntry[Int] =
     createIfNotExists("spark.shuffle.sort.bypassMergeThreshold", builder => {

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleWriter.scala
@@ -37,6 +37,8 @@ private[spark] class SplashShuffleWriter[K, V, C](
     context: TaskContext)
     extends ShuffleWriter[K, V] with Logging {
 
+  private type KVPair = (K, V)
+
   private var sorter: SplashSorter[K, V, _] = _
 
   private var stopping = false

--- a/src/main/scala/org/apache/spark/shuffle/SplashSorter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashSorter.scala
@@ -20,16 +20,14 @@
  */
 package org.apache.spark.shuffle
 
-import java.io.{BufferedInputStream, InputStream}
-import java.util.{Comparator, UUID}
+import java.util.Comparator
 
-import com.google.common.io.ByteStreams
-import com.memverge.splash.{StorageFactoryHolder, TmpShuffleFile}
+import com.memverge.splash.TmpShuffleFile
 import org.apache.spark._
-import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
-import org.apache.spark.serializer.DeserializationStream
-import org.apache.spark.storage.{BlockId, TempShuffleBlockId}
+import org.apache.spark.storage.BlockId
+import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection._
 
 import scala.collection.mutable.ArrayBuffer
@@ -45,8 +43,7 @@ private[spark] class SplashSorter[K, V, C](
 
   private val conf = SparkEnv.get.conf
 
-  private val storageFactory = StorageFactoryHolder.getFactory
-  private val splashAggregator = aggregator.map(new SplashAggregator(_))
+  private val splashAggregatorOpt = aggregator.map(new SplashAggregator(_))
   private val numPartitions = partitioner.map(_.numPartitions).getOrElse(1)
   private val shouldPartition = numPartitions > 1
 
@@ -54,17 +51,9 @@ private[spark] class SplashSorter[K, V, C](
     if (shouldPartition) partitioner.get.getPartition(key) else 0
   }
 
-  // Use getSizeAsKb (not bytes) to maintain backwards compatibility if no units are provided
-  private val fileBufferSize = conf.get(SplashOpts.shuffleFileBufferKB).toInt * 1024
-
-  // Size of object batches when reading/writing from serializers.
-  //
-  // Objects are written in batches, with each batch using its own serialization stream. This
-  // cuts down on the size of reference-tracking maps constructed when deserializing a stream.
-  //
-  // NOTE: Setting this too low can cause excessive copying when serializing, since some serializers
-  // grow internal data structures by growing + copying every time the number of objects doubles.
-  private val serializerBatchSize = conf.getLong("spark.shuffle.spill.batchSize", 10000)
+  private val spillCheckInterval = Math.max(
+    Math.min(conf.get(SplashOpts.spillCheckInterval),
+      conf.get(SplashOpts.forceSpillElements) / 10), 1)
 
   // Data structures to store in-memory objects before we spill. Depending on whether we have an
   // Aggregator set, we either put objects into an AppendOnlyMap where we combine them, or we
@@ -72,14 +61,14 @@ private[spark] class SplashSorter[K, V, C](
   @volatile private var map = new PartitionedAppendOnlyMap[K, C]
   @volatile private var buffer = new PartitionedPairBuffer[K, C]
 
-  private var _bytesSpilled = 0L
+  private type KCPartitioned = ((Int, K), C)
+  private type KCPair = (K, C)
+  private type KVPair = (K, V)
+  private type KCIterator = Iterator[KCPair]
+  private type KCBufferedIterator = BufferedIterator[KCPair]
 
-  type KCPartitioned = ((Int, K), C)
-  type KCIterator = Iterator[Product2[K, C]]
-  type KCBufferedIterator = BufferedIterator[Product2[K, C]]
 
-
-  def bytesSpilled: Long = _bytesSpilled
+  def bytesSpilled: Long = (spills ++ forceSpillFiles).map(_.bytesSpilled).sum
 
   // Peak size of the in-memory data structure observed so far, in bytes
   private var _peakMemoryUsedBytes: Long = 0L
@@ -93,7 +82,7 @@ private[spark] class SplashSorter[K, V, C](
   private val keyComparator: Comparator[K] = ordering.getOrElse(new SplashHashComparator[K])
 
   private def comparator: Option[Comparator[K]] = {
-    if (ordering.isDefined || splashAggregator.isDefined) {
+    if (ordering.isDefined || splashAggregatorOpt.isDefined) {
       Some(keyComparator)
     } else {
       None
@@ -102,63 +91,68 @@ private[spark] class SplashSorter[K, V, C](
 
   private val spills = new ArrayBuffer[SpilledFile]
 
-  private[spark] def numSpills: Int = spills.size
+  private[spark] def spillCount: Int = spills.size
+
+  def insertAll(records: Seq[KVPair]): Unit = insertAll(records.iterator)
 
   def insertAll(records: Iterator[Product2[K, V]]): Unit = {
-    val shouldCombine = splashAggregator.isDefined
-
-    var count = 0
-    if (shouldCombine) {
-      val mergeValue = splashAggregator.get.mergeValue
-      val createCombiner = splashAggregator.get.createCombiner
-      var kv: Product2[K, V] = null
-      val update = (hadValue: Boolean, oldValue: C) => {
-        if (hadValue) mergeValue(oldValue, kv._2) else createCombiner(kv._2)
-      }
-      while (records.hasNext) {
-        addElementsRead()
-        kv = records.next()
-        val partition = getPartition(kv._1)
-        map.changeValue((partition, kv._1), update)
-        maybeSpillCollection(usingMap = true)
-        count += 1
-      }
-      logDebug(s"insert all combined $count records")
-    } else {
-      for (kv <- records) {
-        addElementsRead()
-        buffer.insert(getPartition(kv._1), kv._1, kv._2.asInstanceOf[C])
-        maybeSpillCollection(usingMap = false)
-        count += 1
-      }
-      logDebug(s"insert all not combined $count records")
+    splashAggregatorOpt match {
+      case Some(agg) =>
+        val mergeValue = agg.mergeValue
+        val createCombiner = agg.createCombiner
+        for (kv <- records) {
+          addElementsRead()
+          val partition = getPartition(kv._1)
+          map.changeValue((partition, kv._1), (hadValue: Boolean, oldValue: C) => {
+            if (hadValue) mergeValue(oldValue, kv._2) else createCombiner(kv._2)
+          })
+          maybeSpillCollection(usingMap = true)
+        }
+        logDebug(s"insert all combined records")
+      case None =>
+        for (kv <- records) {
+          addElementsRead()
+          buffer.insert(getPartition(kv._1), kv._1, kv._2.asInstanceOf[C])
+          maybeSpillCollection(usingMap = false)
+        }
+        logDebug(s"insert all not combined records")
     }
+  }
+
+  def updateTaskMetrics(taskMetrics: TaskMetrics = context.taskMetrics()): Unit = {
+    taskMetrics.incMemoryBytesSpilled(memoryBytesSpilled)
+    taskMetrics.incDiskBytesSpilled(bytesSpilled)
+    taskMetrics.incPeakExecutionMemory(peakMemoryUsedBytes)
   }
 
   private def maybeSpillCollection(usingMap: Boolean): Unit = {
-    var estimatedSize = 0L
-    if (usingMap) {
-      estimatedSize = map.estimateSize()
-      if (maybeSpill(map, estimatedSize)) {
-        map = new PartitionedAppendOnlyMap[K, C]
+    if (elementsRead % spillCheckInterval == 0) {
+      var estimatedSize = 0L
+      if (usingMap) {
+        estimatedSize = map.estimateSize()
+        if (maybeSpill(map, estimatedSize)) {
+          map = new PartitionedAppendOnlyMap[K, C]
+        }
+      } else {
+        estimatedSize = buffer.estimateSize()
+        if (maybeSpill(buffer, estimatedSize)) {
+          buffer = new PartitionedPairBuffer[K, C]
+        }
       }
-    } else {
-      estimatedSize = buffer.estimateSize()
-      if (maybeSpill(buffer, estimatedSize)) {
-        buffer = new PartitionedPairBuffer[K, C]
-      }
-    }
 
-    if (estimatedSize > _peakMemoryUsedBytes) {
-      _peakMemoryUsedBytes = estimatedSize
+      _peakMemoryUsedBytes = Math.max(estimatedSize, _peakMemoryUsedBytes)
     }
   }
 
-  /** @inheritdoc */
+  private def spillIterator(iterator: WritablePartitionedIterator[K, C]) =
+    SpilledFile.spill(
+      iterator,
+      serializer)
+
   override protected def spill(collection: WritablePartitionedPairCollection[K, C]): Unit = {
     val inMemoryIterator = destructiveSortedWritablePartitionedIterator(
       collection, comparator)
-    val spilledFile = spillMemoryIterator(inMemoryIterator)
+    val spilledFile = spillIterator(inMemoryIterator)
     spills += spilledFile
   }
 
@@ -166,17 +160,17 @@ private[spark] class SplashSorter[K, V, C](
       collection: WritablePartitionedPairCollection[K, C],
       keyComparator: Option[Comparator[K]]): WritablePartitionedIterator[K, C] = {
     val it = collection.partitionedDestructiveSortedIterator(keyComparator)
-    WritablePartitionedIterator(it)
+    WritablePartitionedIterator(it, numPartitions)
   }
 
-  /** @inheritdoc */
   override protected def forceSpill(): Boolean = {
     if (isShuffleSort) {
       false
     } else {
       assert(readingIterator != null)
       readingIterator.spill() match {
-        case Some(_) =>
+        case Some(spillFile) =>
+          forceSpillFiles += spillFile
           map = null
           buffer = null
           true
@@ -186,80 +180,17 @@ private[spark] class SplashSorter[K, V, C](
     }
   }
 
-  /**
-   * Spill contents of in-memory iterator to a temporary file on storage.
-   */
-  private def spillMemoryIterator(
-      inMemoryIterator: WritablePartitionedIterator[K, C]): SpilledFile = {
-    val spillFile = storageFactory.makeSpillFile()
-
-    var objectsWritten: Long = 0
-    val spillMetrics: ShuffleWriteMetrics = new ShuffleWriteMetrics
-    val blockId = TempShuffleBlockId(spillFile.uuid)
-    val writer = new SplashObjectWriter(
-      blockId,
-      spillFile,
-      serializer,
-      fileBufferSize,
-      spillMetrics)
-
-    val batchSizes = new ArrayBuffer[Long]
-    val elementsPerPartition = new Array[Long](numPartitions)
-
-    def flush(): Unit = {
-      val len = writer.commitAndGet()
-      batchSizes += len
-      _bytesSpilled += len
-      objectsWritten = 0
-    }
-
-    var success = false
-    try {
-      while (inMemoryIterator.hasNext) {
-        val partitionId = inMemoryIterator.nextPartition()
-        require(partitionId >= 0 && partitionId < numPartitions,
-          s"partition Id: $partitionId should be in the range [0, $numPartitions)")
-        inMemoryIterator.writeNext(writer)
-        elementsPerPartition(partitionId) += 1
-        objectsWritten += 1
-
-        if (objectsWritten == serializerBatchSize) {
-          flush()
-        }
-      }
-      if (objectsWritten > 0) {
-        flush()
-      } else {
-        writer.revertPartialWritesAndClose()
-      }
-      success = true
-    } finally {
-      if (success) {
-        writer.close()
-      } else {
-        writer.revertPartialWritesAndClose()
-        spillFile.delete()
-      }
-    }
-
-    SpilledFile(spillFile,
-      TempShuffleBlockId(UUID.randomUUID()),
-      success,
-      batchSizes.toArray,
-      elementsPerPartition)
-  }
-
   private def merge(
       spills: Seq[SpilledFile],
       inMemory: Iterator[KCPartitioned]): Iterator[(Int, KCIterator)] = {
-    val readers = spills.map(new SpillReader(_))
+    val readers = spills.map(getSpillReader)
     val inMemBuffered = inMemory.buffered
     (0 until numPartitions).iterator.map { p =>
       val inMemIterator = new IteratorForPartition(p, inMemBuffered)
       val iterators = readers.map(_.readNextPartition()) ++ Seq(inMemIterator)
-      if (splashAggregator.isDefined) {
+      if (splashAggregatorOpt.isDefined) {
         (p, mergeWithAggregation(
-          iterators, splashAggregator.get.mergeCombiners, keyComparator, ordering.isDefined))
+          iterators, splashAggregatorOpt.get.mergeCombiners))
       } else if (ordering.isDefined) {
         (p, mergeSort(iterators, ordering.get))
       } else {
@@ -271,198 +202,84 @@ private[spark] class SplashSorter[K, V, C](
   private def mergeSort(
       iterators: Seq[KCIterator],
       comparator: Comparator[K]): KCIterator = {
-    Algorithm.mergeSort[Product2[K, C]](
+    Algorithm.mergeSort[KCPair](
       iterators,
-      new Ordering[Product2[K, C]] {
-        override def compare(x: Product2[K, C], y: Product2[K, C]): Int =
+      new Ordering[KCPair] {
+        override def compare(x: KCPair, y: KCPair): Int =
           comparator.compare(x._1, y._1)
       })
   }
 
   private def mergeWithAggregation(
       iterators: Seq[KCIterator],
-      mergeCombiners: (C, C) => C,
-      comparator: Comparator[K],
-      totalOrder: Boolean): KCIterator = {
-    if (!totalOrder) new Iterator[KCIterator] {
-      private val sorted = mergeSort(iterators, comparator).buffered
+      mergeCombiners: (C, C) => C): KCIterator = {
+    ordering match {
+      case Some(_) =>
+        // We have a total ordering, so the objects with the same key are sequential.
+        new KCIterator {
+          private val sorted = mergeSort(iterators, keyComparator).buffered
 
-      // Buffers reused across elements to decrease memory allocation
-      val keys = new ArrayBuffer[K]
-      val combiners = new ArrayBuffer[C]
+          override def hasNext: Boolean = sorted.hasNext
 
-      override def hasNext: Boolean = sorted.hasNext
-
-      override def next(): Iterator[Product2[K, C]] = {
-        if (!hasNext) {
-          throw new NoSuchElementException
-        }
-        keys.clear()
-        combiners.clear()
-        val firstPair = sorted.next()
-        keys += firstPair._1
-        combiners += firstPair._2
-        val key = firstPair._1
-        while (sorted.hasNext && comparator.compare(sorted.head._1, key) == 0) {
-          val pair = sorted.next()
-          var i = 0
-          var foundKey = false
-          while (i < keys.size && !foundKey) {
-            if (keys(i) == pair._1) {
-              combiners(i) = mergeCombiners(combiners(i), pair._2)
-              foundKey = true
+          override def next(): KCPair = {
+            if (!hasNext) {
+              throw new NoSuchElementException
             }
-            i += 1
-          }
-          if (!foundKey) {
-            keys += pair._1
-            combiners += pair._2
-          }
-        }
-
-        // Note that we return an iterator of elements since we could've had many keys marked
-        // equal by the partial order; we flatten this below to get a flat iterator of (K, C).
-        keys.iterator.zip(combiners.iterator)
-      }
-    }.flatMap(i => i) else {
-      // We have a total ordering, so the objects with the same key are sequential.
-      new KCIterator {
-        val sorted: KCBufferedIterator = mergeSort(iterators, comparator).buffered
-
-        override def hasNext: Boolean = sorted.hasNext
-
-        override def next(): Product2[K, C] = {
-          if (!hasNext) {
-            throw new NoSuchElementException
-          }
-          val elem = sorted.next()
-          val k = elem._1
-          var c = elem._2
-          while (sorted.hasNext && sorted.head._1 == k) {
-            val pair = sorted.next()
-            c = mergeCombiners(c, pair._2)
-          }
-          (k, c)
-        }
-      }
-    }
-  }
-
-  private class SpillReader(spill: SpilledFile) {
-    private val batchOffsets = spill.serializerBatchSizes.scanLeft(0L)(_ + _)
-
-    var partitionId = 0
-    var indexInPartition = 0L
-    var batchId = 0
-    var indexInBatch = 0
-    var lastPartitionId = 0
-
-    var inputStream: InputStream = _
-    private var deserializeStream = nextBatchStream()
-
-    var nextItem: (K, C) = _
-    var finished = false
-
-    skipToNextPartition()
-
-    def nextBatchStream(): DeserializationStream = {
-      if (batchId < batchOffsets.length - 1) {
-        closeStreams()
-
-        val start = batchOffsets(batchId)
-        inputStream = spill.file.makeInputStream()
-        inputStream.skip(start)
-        batchId += 1
-
-        val end = batchOffsets(batchId)
-
-        val batchOffsetsStr = batchOffsets.mkString("[", ", ", "]")
-        logDebug(s"start = $start, end = $end, batchOffsets = $batchOffsetsStr")
-
-        val bufferedStream = new BufferedInputStream(
-          ByteStreams.limit(inputStream, end - start), fileBufferSize)
-
-        serializer.deserializeStream(spill.blockId, bufferedStream)
-      } else {
-        cleanup()
-        null
-      }
-    }
-
-    private def skipToNextPartition(): Unit = {
-      while (partitionId < numPartitions &&
-          indexInPartition == spill.elementsPerPartition(partitionId)) {
-        partitionId += 1
-        indexInPartition = 0L
-      }
-    }
-
-    private def readNextItem(): (K, C) = {
-      if (finished || deserializeStream == null) {
-        null
-      } else {
-        val k = deserializeStream.readKey().asInstanceOf[K]
-        val c = deserializeStream.readValue().asInstanceOf[C]
-        lastPartitionId = partitionId
-        indexInBatch += 1
-        if (indexInBatch == serializerBatchSize) {
-          indexInBatch = 0
-          deserializeStream = nextBatchStream()
-        }
-        indexInPartition += 1
-        skipToNextPartition()
-        if (partitionId == numPartitions) {
-          finished = true
-          if (deserializeStream != null) {
-            deserializeStream.close()
+            val elem = sorted.next()
+            val k = elem._1
+            var c = elem._2
+            while (sorted.hasNext && sorted.head._1 == k) {
+              val pair = sorted.next()
+              c = mergeCombiners(c, pair._2)
+            }
+            (k, c)
           }
         }
-        (k, c)
-      }
-    }
+      case _ =>
+        val iterator: Iterator[KCIterator] = new Iterator[KCIterator] {
+          private val sorted = mergeSort(iterators, keyComparator).buffered
 
-    var nextPartitionToRead = 0
+          // Buffers reused across elements to decrease memory allocation
+          val keys = new ArrayBuffer[K]
+          val combiners = new ArrayBuffer[C]
 
-    def readNextPartition(): KCIterator = new KCIterator {
-      private val myPartition = nextPartitionToRead
-      nextPartitionToRead += 1
+          override def hasNext: Boolean = sorted.hasNext
 
-      override def hasNext: Boolean = {
-        if (nextItem == null) {
-          nextItem = readNextItem()
-          if (nextItem == null) {
-            return false
+          override def next(): KCIterator = {
+            if (!hasNext) {
+              throw new NoSuchElementException
+            }
+            keys.clear()
+            combiners.clear()
+            val firstPair = sorted.next()
+            keys += firstPair._1
+            combiners += firstPair._2
+            val key = firstPair._1
+            while (sorted.hasNext && keyComparator.compare(sorted.head._1, key) == 0) {
+              val pair = sorted.next()
+              var i = 0
+              var foundKey = false
+              while (i < keys.size && !foundKey) {
+                if (keys(i) == pair._1) {
+                  combiners(i) = mergeCombiners(combiners(i), pair._2)
+                  foundKey = true
+                }
+                i += 1
+              }
+              if (!foundKey) {
+                keys += pair._1
+                combiners += pair._2
+              }
+            }
+
+            // Note that we return an iterator of elements since we could've had many keys marked
+            // equal by the partial order; we flatten this below to get a flat iterator of (K, C).
+            keys.iterator.zip(combiners.iterator)
           }
         }
-        assert(lastPartitionId >= myPartition)
-        lastPartitionId == myPartition
-      }
-
-      override def next(): Product2[K, C] = {
-        if (!hasNext) {
-          throw new NoSuchElementException
-        }
-        val item = nextItem
-        nextItem = null
-        item
-      }
+        iterator.flatten
     }
 
-    def cleanup(): Unit = {
-      batchId = batchOffsets.length
-      closeStreams()
-    }
-
-    private def closeStreams(): Unit = {
-      if (deserializeStream != null) {
-        deserializeStream.close()
-        deserializeStream = null
-      }
-      if (inputStream != null) {
-        inputStream.close()
-        inputStream = null
-      }
-    }
   }
 
   def destructiveIterator(
@@ -473,21 +290,25 @@ private[spark] class SplashSorter[K, V, C](
       readingIterator = new SplashSpillableIterator(
         memoryIterator,
         spillInMemoryIterator,
-        getNextUpstream)
+        spilledFile => getSpillReader(spilledFile).iterator())
       readingIterator
     }
   }
 
+  private def spillInMemoryIterator(upstream: Iterator[KCPartitioned]): SpilledFile = {
+    val inMemoryIterator = WritablePartitionedIterator(upstream, numPartitions)
+    val spilledFile = spillIterator(inMemoryIterator)
+    forceSpillFiles += spilledFile
+    spilledFile
+  }
+
   def partitionedIterator: Iterator[(Int, KCIterator)] = {
-    val usingMap = splashAggregator.isDefined
+    val usingMap = splashAggregatorOpt.isDefined
     val collection = if (usingMap) map else buffer
     if (spills.isEmpty) {
-      if (ordering.isEmpty) {
-        groupByPartition(destructiveIterator(collection.partitionedDestructiveSortedIterator(None)))
-      } else {
-        groupByPartition(destructiveIterator(
-          collection.partitionedDestructiveSortedIterator(Some(keyComparator))))
-      }
+      groupByPartition(
+        destructiveIterator(
+          collection.partitionedDestructiveSortedIterator(ordering)))
     } else {
       merge(spills, destructiveIterator(
         collection.partitionedDestructiveSortedIterator(comparator)))
@@ -499,13 +320,11 @@ private[spark] class SplashSorter[K, V, C](
     partitionedIterator.flatMap(pair => pair._2)
   }
 
-  def toSet: Set[(Int, Set[Product2[K, C]])] = {
+  def toSet: Set[(Int, Set[KCPair])] = {
     partitionedIterator.map(p => (p._1, p._2.toSet)).toSet
   }
 
-  def toSeq: Seq[Product2[K, C]] = {
-    iterator.toSeq
-  }
+  def toSeq: Seq[KCPair] = iterator.toSeq
 
   def writePartitionedFile(
       blockId: BlockId,
@@ -515,15 +334,14 @@ private[spark] class SplashSorter[K, V, C](
       blockId,
       tmpShuffleFile,
       serializer,
-      fileBufferSize,
       context.taskMetrics().shuffleWriteMetrics)
 
     if (spills.isEmpty) {
-      val collection = if (splashAggregator.isDefined) map else buffer
+      val collection = if (splashAggregatorOpt.isDefined) map else buffer
       val it = destructiveSortedWritablePartitionedIterator(collection, comparator)
       while (it.hasNext) {
-        val partitionId = it.nextPartition()
-        while (it.hasNext && it.nextPartition() == partitionId) {
+        val partitionId = it.partitionId
+        while (it.hasNext && it.partitionId == partitionId) {
           it.writeNext(writer)
         }
         lengths(partitionId) = writer.commitAndGet()
@@ -540,19 +358,15 @@ private[spark] class SplashSorter[K, V, C](
     }
 
     writer.close()
-    context.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
-    context.taskMetrics().incDiskBytesSpilled(bytesSpilled)
-    context.taskMetrics().incPeakExecutionMemory(peakMemoryUsedBytes)
-
+    updateTaskMetrics()
     lengths
   }
 
   def stop(): Unit = {
     logDebug("Stop SpillSorter and clear " +
         s"${spills.length + forceSpillFiles.length} spills.")
-    spills.foreach(s => s.file.delete())
+    (spills ++ forceSpillFiles).foreach(_.file.delete())
     spills.clear()
-    forceSpillFiles.foreach(s => s.file.delete())
     forceSpillFiles.clear()
     if (map != null || buffer != null) {
       map = null
@@ -560,6 +374,9 @@ private[spark] class SplashSorter[K, V, C](
       releaseMemory()
     }
   }
+
+  def completionIterator: CompletionIterator[KCPair, KCIterator] =
+    CompletionIterator[KCPair, KCIterator](iterator, stop())
 
   private def groupByPartition(data: Iterator[KCPartitioned]): Iterator[(Int, KCIterator)] = {
     val buffered = data.buffered
@@ -570,7 +387,7 @@ private[spark] class SplashSorter[K, V, C](
       partitionId: Int, data: BufferedIterator[KCPartitioned]) extends KCIterator {
     override def hasNext: Boolean = data.hasNext && data.head._1._1 == partitionId
 
-    override def next(): Product2[K, C] = {
+    override def next(): KCPair = {
       if (!hasNext) {
         throw new NoSuchElementException
       }
@@ -579,31 +396,7 @@ private[spark] class SplashSorter[K, V, C](
     }
   }
 
-  private def spillInMemoryIterator(upstream: Iterator[KCPartitioned]): SpilledFile = {
-    val inMemoryIterator = WritablePartitionedIterator(upstream)
-    val spilledFile = spillMemoryIterator(inMemoryIterator)
-    forceSpillFiles += spilledFile
-    spilledFile
+  private def getSpillReader(spilledFile: SpilledFile): PartitionedSpillReader[K, C] = {
+    new PartitionedSpillReader(spilledFile, serializer)
   }
-
-  private def getNextUpstream(spilledFile: SpilledFile): Iterator[KCPartitioned] = {
-    val spillReader = new SpillReader(spilledFile)
-    (0 until numPartitions).iterator.flatMap { p =>
-      val iterator = spillReader.readNextPartition()
-      iterator.map(cur => ((p, cur._1), cur._2))
-    }
-  }
-}
-
-private[spark] case class WritablePartitionedIterator[K, V](it: Iterator[((Int, K), V)]) {
-  private[this] var cur = if (it.hasNext) it.next() else null
-
-  def writeNext(writer: SplashObjectWriter): Unit = {
-    writer.write(cur._1._2, cur._2)
-    cur = if (it.hasNext) it.next() else null
-  }
-
-  def hasNext: Boolean = cur != null
-
-  def nextPartition(): Int = cur._1._1
 }

--- a/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorter.scala
@@ -69,7 +69,6 @@ private[spark] class SplashUnsafeSorter(
   private val initialSize: Int = conf.get(SplashOpts.shuffleInitialBufferSize)
   private val numElementsForSpillThreshold: Int = conf.get(SplashOpts.forceSpillElements)
   private val useRadixSort = conf.get(SplashOpts.useRadixSort)
-  private val fileBufferSize = conf.get(SplashOpts.shuffleFileBufferKB).toInt * 1024
 
   private var inMemSorter =
     new ShuffleInMemorySorter(this, initialSize, useRadixSort)
@@ -97,6 +96,8 @@ private[spark] class SplashUnsafeSorter(
     // This call performs the actual sort
     val sortedRecords = inMemSorter.getSortedIterator
 
+    val fileBufferSize = storageFactory.getFileBufferSize
+
     // cache to buffer small writes
     val writeBuffer = new Array[Byte](fileBufferSize)
     val blockId = TempShuffleBlockId(UUID.randomUUID())
@@ -109,7 +110,6 @@ private[spark] class SplashUnsafeSorter(
       blockId,
       tmpSpillFile,
       serializer,
-      fileBufferSize,
       writeMetricsToUse)
 
     var currentPartition = -1

--- a/src/test/java/com/memverge/splash/ManualCloseOutputStreamTest.java
+++ b/src/test/java/com/memverge/splash/ManualCloseOutputStreamTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import lombok.val;
+import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@Test(groups = {"UnitTest", "IntegrationTest"})
+public class ManualCloseOutputStreamTest {
+
+  private StorageFactory factory = StorageFactoryHolder.getFactory();
+
+  @AfterClass
+  private void afterClass() {
+    factory.reset();
+  }
+
+  public void testManualClose() throws IOException {
+    val file = factory.makeSpillFile();
+    val size = 6;
+    val os = file.makeBufferedManualCloseOutputStream();
+    os.write("123");
+    os.close();
+    os.write("456");
+    os.manualClose();
+
+    try (val is = file.makeInputStream()) {
+      val buffer = new byte[size];
+      assertThat(is.read(buffer)).isEqualTo(size);
+      assertThat(new String(buffer)).isEqualTo("123456");
+    }
+  }
+
+  public void testWriteAfterClose() throws IOException {
+    val file = factory.makeSpillFile();
+    val os = file.makeBufferedManualCloseOutputStream();
+    os.write("123");
+    os.manualClose();
+
+    assertThatExceptionOfType(IOException.class).isThrownBy(() -> {
+      os.write("456");
+      os.manualClose();
+    });
+  }
+
+  public void testGetCount() throws IOException {
+    val file = factory.makeSpillFile();
+    try (val os = file.makeBufferedManualCloseOutputStream()) {
+      os.write("123");
+      assertThat(os.getCount()).isEqualTo(3);
+
+      os.write("456");
+      assertThat(os.getCount()).isEqualTo(6);
+      os.manualClose();
+    }
+  }
+
+  public void testMetrics() throws IOException {
+    val metrics = new ShuffleWriteMetrics();
+    val file = factory.makeSpillFile();
+
+    try (val os = file.makeBufferedManualCloseOutputStream(metrics)) {
+      assertThat(metrics.shuffleWriteTime()).isEqualTo(0);
+
+      for (int i = 0; i < 100; i++) {
+        os.write(i);
+      }
+
+      assertThat(metrics.shuffleWriteTime()).isGreaterThan(0L);
+      os.manualClose();
+    }
+  }
+}

--- a/src/test/java/com/memverge/splash/ShuffleFileTest.java
+++ b/src/test/java/com/memverge/splash/ShuffleFileTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import lombok.val;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@Test(groups = {"UnitTest", "IntegrationTest"})
+public class ShuffleFileTest {
+
+  private StorageFactory factory = StorageFactoryHolder.getFactory();
+
+  @AfterClass
+  private void afterClass() {
+    factory.reset();
+  }
+
+  private TmpShuffleFile getTestFile() throws IOException {
+    val spill = factory.makeSpillFile();
+    try (val os = spill.makeOutputStream()) {
+      os.write("123456".getBytes());
+    }
+    return spill;
+  }
+
+  public void testMakeBufferedInputStreamWithin() throws IOException {
+    val spill = getTestFile();
+
+    try (val is = spill.makeBufferedInputStreamWithin(2, 4)) {
+      val buffer = new byte[10];
+      assertThat(is.read(buffer)).isEqualTo(2);
+      assertThat(new String(buffer)).startsWith("34");
+    }
+  }
+
+  public void testMakeBufferedInputStreamFrom() throws IOException {
+    val spill = getTestFile();
+
+    try (val is = spill.makeBufferedInputStreamWithin(3, -1)) {
+      val buffer = new byte[10];
+      assertThat(is.read(buffer)).isEqualTo(3);
+      assertThat(new String(buffer)).startsWith("456");
+    }
+  }
+}

--- a/src/test/java/com/memverge/splash/TmpShuffleFileTest.java
+++ b/src/test/java/com/memverge/splash/TmpShuffleFileTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import lombok.val;
+import org.testng.annotations.Test;
+
+@Test(groups = {"UnitTest", "IntegrationTest"})
+public class TmpShuffleFileTest {
+  private StorageFactory factory = StorageFactoryHolder.getFactory();
+
+  public void testUUID() throws IOException {
+    val spill = factory.makeSpillFile();
+    assertThat(spill.uuid()).isNotNull();
+  }
+
+  public void testOverwriteExistingFile() throws IOException {
+    val folder = factory.getShuffleFolder("tmpShuffleFileTest");
+    val dataPath = String.format("%s/shuffle_7_7.data", folder);
+    val file = factory.makeDataFile(dataPath);
+    try (val os = file.makeBufferedOutputStream()) {
+      os.write("hello".getBytes());
+    }
+    try (val os = file.makeBufferedOutputStream()) {
+      os.write("world".getBytes());
+    }
+    file.commit();
+  }
+}

--- a/src/test/resources/integration.xml
+++ b/src/test/resources/integration.xml
@@ -15,6 +15,7 @@
       </run>
     </groups>
     <packages>
+      <package name="com.memverge.splash.*"/>
       <package name="org.apache.spark.shuffle.*"/>
     </packages>
     <classes>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -15,11 +15,12 @@
       </run>
     </groups>
     <packages>
+      <package name="com.memverge.splash.*"/>
       <package name="org.apache.spark.shuffle.*"/>
     </packages>
     <classes>
-      <class name="org.apache.spark.shuffle.sort.SplashUnsafeSorterTest" />
-      <class name="org.apache.spark.shuffle.sort.SplashUnsafeShuffleWriterTest" />
+      <class name="org.apache.spark.shuffle.sort.SplashUnsafeSorterTest"/>
+      <class name="org.apache.spark.shuffle.sort.SplashUnsafeShuffleWriterTest"/>
     </classes>
   </test>
 </suite>

--- a/src/test/scala/com/memverge/splash/BufferedIteratorTest.scala
+++ b/src/test/scala/com/memverge/splash/BufferedIteratorTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash
+
+import org.assertj.core.api.Assertions.{assertThat, assertThatExceptionOfType}
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+import org.testng.annotations.Test
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class BufferedIteratorTest {
+  def testFillSmallerThanBuffer(): Unit = {
+    val buffer = BufferedIterator(IntIterator(5), 10)
+    buffer.fill()
+    assertThat(buffer.bufferLastOpt().getOrElse(-1)).isEqualTo(4)
+  }
+
+  def testFillLargerThanBuffer(): Unit = {
+    val buffer = BufferedIterator(IntIterator(20), 10)
+    buffer.fill()
+    assertThat(buffer.bufferLastOpt().getOrElse(-1)).isEqualTo(9)
+  }
+
+  def testNextWithoutReFill(): Unit = {
+    val buffer = BufferedIterator(IntIterator(10), 5)
+    assertThat(buffer.hasNext).isTrue
+    assertThat(buffer.next()).isEqualTo(0)
+    assertThat(buffer.hasNext).isTrue
+    assertThat(buffer.next()).isEqualTo(1)
+  }
+
+  def testNextWithReFill(): Unit = {
+    val buffer = BufferedIterator(IntIterator(5), 2)
+    (0 to 4).foreach(i => {
+      assertThat(buffer.hasNext).isTrue
+      assertThat(buffer.next()).isEqualTo(i)
+    })
+    verifyNoElementAvailable(buffer)
+  }
+
+  private def verifyNoElementAvailable(buffer: BufferedIterator[Int]):Unit = {
+    assertThat(buffer.hasNext).isFalse
+    assertThatExceptionOfType(classOf[NoSuchElementException])
+        .isThrownBy(new ThrowingCallable {
+          override def call(): Unit = buffer.next()
+        })
+  }
+
+  def testNextOnEmptyCollection(): Unit = {
+    val buffer = BufferedIterator(IntIterator(0), 10)
+    verifyNoElementAvailable(buffer)
+  }
+
+  def testNextWithMultipleReFills(): Unit = {
+    val buffer = BufferedIterator(IntIterator(50), 2)
+    (0 to 49).foreach(i => {
+      assertThat(buffer.hasNext).isTrue
+      assertThat(buffer.next()).isEqualTo(i)
+    })
+    verifyNoElementAvailable(buffer)
+  }
+
+  def testNextWithSingleFill(): Unit = {
+    val buffer = BufferedIterator(IntIterator(2), 5)
+    (0 to 1).foreach(i => {
+      assertThat(buffer.hasNext).isTrue
+      assertThat(buffer.next()).isEqualTo(i)
+    })
+    verifyNoElementAvailable(buffer)
+  }
+
+  def testLastOptOnEmptyCollection(): Unit = {
+    val buffer = BufferedIterator(IntIterator(0))
+    assertThat(buffer.bufferLastOpt()).isEqualTo(None)
+  }
+}
+
+
+case class IntIterator(limit: Int) extends Iterator[Int]{
+  private var value = 0
+
+  override def next(): Int = {
+    val ret = value
+    value += 1
+    ret
+  }
+
+  override def hasNext: Boolean = value < limit
+}

--- a/src/test/scala/org/apache/spark/shuffle/SpilledFileTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SpilledFileTest.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import com.memverge.splash.StorageFactoryHolder
+import org.assertj.core.api.Assertions.{assertThat, assertThatExceptionOfType}
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+import org.testng.annotations.{AfterMethod, BeforeMethod, Test}
+
+import scala.util.Random
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class SpilledFileTest {
+  private val factory = StorageFactoryHolder.getFactory
+  private val originalBatchSize = SpilledFile.serializeBatchSize
+  private val serializer: SplashSerializer = TestUtil.kryoSerializer
+
+  @BeforeMethod
+  private def beforeMethod(): Unit = {
+    SpilledFile.serializeBatchSize = originalBatchSize
+  }
+
+  @AfterMethod
+  private def afterMethod(): Unit = {
+    factory.reset()
+    assertThat(factory.getTmpFileCount).isEqualTo(0)
+  }
+
+  def testFailedSpilledFile(): Unit = {
+    val tmpFile = factory.makeSpillFile()
+    tmpFile.recall()
+    val spilledFile = SpilledFile(tmpFile)
+    assertThat(spilledFile.bytesSpilled) isEqualTo 0
+  }
+
+  private def partitionedArray = Array[((Int, Int), String)](
+    ((0, 4), "04"),
+    ((2, 2), "22"),
+    ((2, 3), "23"),
+    ((3, 6), "36"))
+
+  private def partitionedData = {
+    WritablePartitionedIterator(partitionedArray.iterator, 4)
+  }
+
+  def testBatchSizes(): Unit = {
+    val file = SpilledFile(factory.makeSpillFile(),
+      Array(0, 12, 42, 57, 89))
+    assertThat(file.bytesSpilled).isEqualTo(89)
+    assertThat(file.batchSizes).isEqualTo(Array[Long](12, 30, 15, 32))
+  }
+
+  def testPartitionedSpillIterator(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    val spillReader = new PartitionedSpillReader(spill, serializer)
+    assertThat(spillReader.toArray).isEqualTo(
+      Array((4, "04"), (2, "22"), (3, "23"), (6, "36")))
+  }
+
+  def testPartitionedSpill(): Unit = {
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    assertThat(spill.batchOffsets).isEqualTo(Array[Long](0, 66))
+    assertThat(spill.elementsPerPartition).isEqualTo(Array[Long](1, 0, 2, 1))
+    val spillReader = new PartitionedSpillReader(spill, serializer)
+    assertThat(spillReader.iterator().toArray).isEqualTo(partitionedArray)
+  }
+
+  def testPartitionedSpillWithMultipleBatches(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    assertThat(spill.batchOffsets).isEqualTo(Array[Long](0, 54, 108))
+    assertThat(spill.bytesSpilled).isEqualTo(108)
+    assertThat(spill.elementsPerPartition).isEqualTo(Array[Long](1, 0, 2, 1))
+  }
+
+  def testReadPartitionedSpillWithMultipleBatches(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    val spillReader = new PartitionedSpillReader(spill, serializer)
+    assertThat(spillReader.iterator().toArray).isEqualTo(partitionedArray)
+  }
+
+  def testReadPartitionedSpillTwice(): Unit = {
+    val spill = SpilledFile.spill(partitionedData, serializer)
+
+    val spillReader0 = new PartitionedSpillReader(spill, serializer)
+    assertThat(spillReader0.iterator().toArray).isEqualTo(partitionedArray)
+
+    val spillReader1 = new PartitionedSpillReader(spill, serializer)
+    assertThat(spillReader1.iterator().toArray).isEqualTo(partitionedArray)
+  }
+
+  def testReadNextPartition(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    val spillReader = new PartitionedSpillReader(spill, serializer)
+    val p0 = spillReader.readNextPartition()
+    assertThat(p0.toArray).isEqualTo(Array((4, "04")))
+
+    val p1 = spillReader.readNextPartition()
+    assertThat(p1.isEmpty).isTrue
+
+    val p2 = spillReader.readNextPartition()
+    assertThat(p2.toArray).isEqualTo(Array((2, "22"), (3, "23")))
+
+    val p3 = spillReader.readNextPartition()
+    assertThat(p3.toArray).isEqualTo(Array((6, "36")))
+
+    val p4 = spillReader.readNextPartition()
+    assertThat(p4.isEmpty).isTrue
+  }
+
+  def testReadNextPartitionInNormalSequence(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(partitionedData, serializer)
+    val spillReader = new PartitionedSpillReader(spill, serializer)
+    val p0 = spillReader.readNextPartition()
+    val p1 = spillReader.readNextPartition()
+    val p2 = spillReader.readNextPartition()
+    val p3 = spillReader.readNextPartition()
+    val p4 = spillReader.readNextPartition()
+
+    assertThat(p0.toArray).isEqualTo(Array((4, "04")))
+    assertThat(p1.isEmpty).isTrue
+    assertThat(p2.toArray).isEqualTo(Array((2, "22"), (3, "23")))
+    assertThat(p3.toArray).isEqualTo(Array((6, "36")))
+    assertThat(p4.isEmpty).isTrue
+  }
+
+  def testSpillSizeWithoutBatchSize(): Unit = {
+    val spill = factory.makeSpillFile()
+    val text = "hello"
+    SplashUtils.withResources(spill.makeOutputStream()) { os =>
+      os.write(text.getBytes())
+    }
+    val spilledFile = SpilledFile(spill)
+    assertThat(spilledFile.bytesSpilled).isEqualTo(text.length)
+  }
+
+  private def pairData: Iterator[(Int, String)] = {
+    Array((4, "s4"),
+      (2, "s2"),
+      (3, "s3"),
+      (6, "s6"),
+      (7, "s7")).iterator
+  }
+
+  def testPairSpill(): Unit = {
+    val spill = SpilledFile.spill(pairData, serializer)
+    assertThat(spill.bytesSpilled).isEqualTo(72)
+    assertThat(spill.batchOffsets).isEqualTo(Array[Long](0, 72))
+    assertThat(spill.elementsPerPartition).isEqualTo(Array.empty[Long])
+  }
+
+  def testReadSpilledPair(): Unit = {
+    val spill = SpilledFile.spill(pairData, serializer)
+    val iterator = new PairSpillReader[Int, String](spill, serializer)
+    assertThat(iterator.toArray).isEqualTo(pairData.toArray)
+  }
+
+  def testReadSpilledPairTwice(): Unit = {
+    val spill = SpilledFile.spill(pairData, serializer)
+    val iterator0 = new PairSpillReader[Int, String](spill, serializer)
+    assertThat(iterator0.toArray).isEqualTo(pairData.toArray)
+
+    val iterator1 = new PairSpillReader[Int, String](spill, serializer)
+    assertThat(iterator1.toArray).isEqualTo(pairData.toArray)
+  }
+
+  def testPairSpillWithMultipleBatches(): Unit = {
+    SpilledFile.serializeBatchSize = 2
+    val spill = SpilledFile.spill(pairData, serializer)
+    assertThat(spill.bytesSpilled).isEqualTo(156)
+    assertThat(spill.batchOffsets).isEqualTo(Array[Long](0, 54, 108, 156))
+    val iterator = new PairSpillReader[Int, String](spill, serializer)
+    assertThat(iterator.toArray).isEqualTo(pairData.toArray)
+  }
+
+  def testReadLimitedPairSpill(): Unit = {
+    SpilledFile.serializeBatchSize = 1
+    val spill = SpilledFile.spill(pairData, serializer)
+    val iterator = new PairSpillReader[Int, String](spill, serializer).limit(1, 3)
+    assertThat(iterator.toArray).isEqualTo(Array((2, "s2"), (3, "s3")))
+  }
+
+  def testLimitNoDataAvailable(): Unit = {
+    val spill = SpilledFile.spill(pairData, serializer)
+    val iterator = new PairSpillReader[Int, String](spill, serializer).limit(1, 2)
+    assertThat(iterator.isEmpty).isTrue
+    assertThatExceptionOfType(classOf[NoSuchElementException])
+        .isThrownBy(new ThrowingCallable {
+          override def call(): Unit = iterator.next()
+        })
+  }
+
+  def testRecallSpillFileIfNoSpill(): Unit = {
+    val spill = SpilledFile.spill(Iterator.empty, serializer)
+    assertThat(spill.file.exists()).isFalse
+  }
+
+  @Test(enabled = false)
+  def testSpillReaderPerformance(): Unit = {
+    val size = 20000000L
+    val rand = new Random(1)
+    val data = (1L to size).map(i => (i, rand.nextLong()))
+    val spill = SpilledFile.spill(data.iterator, serializer)
+    var theSum = 0L
+    TestUtil.time {
+      val iterator = new PairSpillReader[Long, Long](spill, serializer)
+      theSum = iterator.map(x => x._1).sum
+      assertThat(theSum).isEqualTo(200000010000000L)
+    }(50)
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/SplashAppendOnlyMapTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashAppendOnlyMapTest.scala
@@ -51,6 +51,7 @@ class SplashAppendOnlyMapTest {
 
   @BeforeMethod
   def beforeMethod(): Unit = {
+    afterMethod()
     context = TestUtil.newTaskContext(sc.conf)
   }
 
@@ -265,7 +266,7 @@ class SplashAppendOnlyMapTest {
     val consumer = createMap[String]
     map.insertAll((1 to rddSize).iterator.map(_.toString).map(i => (i, i)))
     assertThat(map.spill(10000, consumer)) isGreaterThan 0L
-    assertThat(map.bytesSpilled) isEqualTo 8580L
+    assertThat(map.bytesSpilled) isEqualTo 34861L
     map.cleanupSpillFile()
     consumer.cleanupSpillFile()
   }
@@ -298,7 +299,7 @@ class SplashAppendOnlyMapTest {
       map.insert(w1, w2)
       map.insert(w2, w1)
     }
-    assertThat(SplashAppendOnlyMap.spilledCount) isGreaterThan 0
+    assertThat(map.spillCount) isGreaterThan 0
 
     // A map of collision pairs in both directions
     val collisionPairsMap = (collisionPairs ++ collisionPairs.map(_.swap)).toMap
@@ -328,7 +329,7 @@ class SplashAppendOnlyMapTest {
       }
     }
 
-    assertThat(SplashAppendOnlyMap.spilledCount) isGreaterThan 0
+    assertThat(map.spillCount) isGreaterThan 0
 
     val it = map.iterator
     var count = 0

--- a/src/test/scala/org/apache/spark/shuffle/SplashOptsTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashOptsTest.scala
@@ -23,7 +23,7 @@ class SplashOptsTest {
   private val conf = TestUtil.newSparkConf()
 
   def testDefaultValues(): Unit = {
-    assertThat(conf.get(SplashOpts.shuffleFileBufferKB)) isEqualTo 32
+    assertThat(conf.get(SplashOpts.shuffleFileBufferKB)) isEqualTo 32L
     assertThat(conf.get(SplashOpts.shuffleInitialBufferSize)) isEqualTo 4096
     assertThat(conf.get(SplashOpts.storageFactoryName)) isNotEmpty()
     assertThat(conf.get(SplashOpts.memoryMapThreshold)) isGreaterThan 0L

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleFetcherIteratorTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleFetcherIteratorTest.scala
@@ -1,0 +1,99 @@
+/*
+ * Modifications copyright (C) 2018 MemVerge Inc.
+ *
+ * Replace the original shuffle class with Splash version classes.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import com.memverge.splash.StorageFactoryHolder
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.storage.{ShuffleBlockId, TestBlockId}
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Fail.fail
+import org.testng.annotations.{AfterMethod, BeforeMethod, Test}
+
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class SplashShuffleFetcherIteratorTest {
+  private val appId = "SplashShuffleFetcherIteratorTest"
+  private val factory = StorageFactoryHolder.getFactory
+  private var resolver: SplashShuffleBlockResolver = _
+
+  @BeforeMethod
+  private def beforeMethod(): Unit = {
+    resolver = new SplashShuffleBlockResolver(appId)
+  }
+
+  @AfterMethod
+  private def afterMethod(): Unit = {
+    factory.reset()
+    assertThat(factory.getShuffleFileCount(appId)) isEqualTo 0
+    assertThat(factory.getTmpFileCount) isEqualTo 0
+  }
+
+  def testNext(): Unit = {
+    val blocks = List(
+      resolver.putShuffleBlock(2, 1, Array(10L, 20L, 30L)),
+      resolver.putShuffleBlock(2, 2, Array(30L, 15L, 22L)))
+    val fetchers = SplashShuffleFetcherIterator(resolver, blocks.iterator)
+    assertThat(fetchers.hasNext).isTrue
+    val fetcher1 = fetchers.next()
+    assertThat(fetcher1.blockId) isEqualTo ShuffleBlockId(2, 1, 0)
+    assertThat(fetcher1.length) isEqualTo 10
+    fetcher1.close()
+
+    val fetcher2 = fetchers.next()
+    assertThat(fetcher2.blockId) isEqualTo ShuffleBlockId(2, 2, 0)
+    assertThat(fetcher2.length) isEqualTo 30
+    fetcher2.close()
+  }
+
+  def testDumpOnError(): Unit = {
+    val serializer = TestUtil.kryoSerializer
+    val blocks = List(
+      resolver.putShuffleBlock(3, 1, Array(10L, 20L, 30L)),
+      resolver.putShuffleBlock(3, 2, Array(30L, 15L, 22L)))
+    val fetchers = SplashShuffleFetcherIterator(resolver, blocks.iterator)
+    val iterator = fetchers.flatMap(
+      fetcher => fetcher.asMetricIterator(serializer, TaskMetrics.empty))
+    try {
+      iterator.next()
+      fail("should have raised an exception.")
+    } catch {
+      case _: Exception =>
+        val path = resolver.getDumpFilePath(ShuffleBlockId(3, 2, 0))
+        assertThat(path.toFile.exists()).isTrue
+    }
+  }
+
+  def testNoNextValue(): Unit = {
+    val blocks = List(TestBlockId("block-1"))
+    val fetchers = SplashShuffleFetcherIterator(resolver, blocks.iterator)
+    assertThat(fetchers.hasNext).isFalse
+  }
+
+  def testSkipNonShuffleBlocks(): Unit = {
+    val blocks = List(
+      TestBlockId("block-1"),
+      TestBlockId("block-2"),
+      resolver.putShuffleBlock(4, 2, Array(30L, 15L, 22L)))
+    val fetchers = SplashShuffleFetcherIterator(resolver, blocks.iterator).toArray
+    assertThat(fetchers.length) isEqualTo 1
+    fetchers.foreach(_.close())
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
@@ -28,7 +28,7 @@ import org.testng.annotations.Test
 class SplashShuffleManagerTest {
   def testVersion(): Unit = {
     val version = SplashShuffleManager.version
-    assertThat(version).matches("\\d+\\.\\d+\\.\\d+")
+    assertThat(version).matches("\\d+\\.\\d+(\\.\\d+)+")
   }
 
   def testStopWithoutApp(): Unit = {

--- a/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
+++ b/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
@@ -99,10 +99,11 @@ object TestUtil {
       .set("spark.ui.enabled", "false")
       .set("spark.shuffle.manager", classOf[SplashShuffleManager].getName)
       .set("spark.hadoop.validateOutputSpecs", "false")
-      .set("spark.shuffle.compress", "true")
-      .set("spark.shuffle.spill.batchSize", "10")
+      .set(SplashOpts.shuffleCompress, true)
+      .set(SplashOpts.serializeBatchSize, 10L)
       .set("spark.shuffle.spill.initialMemoryThreshold", "512")
-      .set("spark.shuffle.sort.bypassMergeThreshold", "0")
+      .set(SplashOpts.bypassSortThreshold, 0)
+      .set(SplashOpts.spillCheckInterval, 1)
       .set("splash.local.internal.alwaysRemote", "false")
 
   def hashBasedConf(conf: SparkConf): SparkConf =
@@ -131,8 +132,7 @@ object TestUtil {
       aggregator,
       partitioner,
       ordering,
-      SplashSerializer(new JavaSerializer(conf))
-    )
+      SplashSerializer(new JavaSerializer(conf)))
   }
 
   def newSparkContext(conf: SparkConf): SparkContext = {
@@ -190,9 +190,10 @@ object TestUtil {
   def confWithStorageFactory(factoryName: String): SparkConf =
     confWithKryo.set("spark.shuffle.splash.storageFactory", factoryName)
 
-  def getSparkConfArray: Array[SparkConf] = {
-    Array(confWithKryo, confWithoutKryo)
-  }
+  def getSparkConfArray: Array[SparkConf] = Array(confWithKryo, confWithoutKryo)
+
+  def kryoSerializer: SplashSerializer =
+    SplashSerializer.kryo(TestUtil.confWithKryo)
 
   def time[R](block: => Unit)(implicit repeats: Int = 1): Unit = {
     val timeInMillis = (0 to repeats).map { i =>

--- a/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorterTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorterTest.scala
@@ -26,6 +26,8 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.{AfterMethod, DataProvider, Test}
 
+import scala.collection.mutable
+
 @Test(groups = Array("UnitTest", "IntegrationTest"))
 class SplashUnsafeSorterTest {
   private var sc: SparkContext = _


### PR DESCRIPTION
The code of shuffle reader is not well structured and lack the
capability of inserting tests for those classes.  The separation of
responsibility is not clear.  Re-structure the code to separate the
responsibility, reduce duplication and increase test coverage.  Here are
the details:
* Insert the error handling and dump logic in the correct
  place and test the dump logic in the unit test.
* Remove the state in `SplashShuffleFetchIterator` and make it a `case class`.
* Extract the `SplashShuffleFetcher` class which is responsible for:
  * Track the resource usage and resource cleanup of the current partition.
  * Error handling and trace information of the current partition.
  * Data transformation related the current partition.
* Extract the iterator wrapper in `SplashShuffleReader` to separate functions
  * `getAggregatedIterator` adds the combiner logic into the iterator
  * `getSortedIterator` adds the sorter logic into the iterator.
* Move all sorter related metrics tracking logic into the sorter itself.
* Extract the `ManualCloseOutputStream` class to it's own file and make
  it explicitly extend from the `OutputStream`.  A separate unittest
  class `ManualCloseOutputStreamTest` is craeted to verify the logic of
  this class.
  * It also tracks the shuffle data if `ShuffleWriteMetrics` is supplied
    for this class.
  * It tracks the number of bytes it writes.
  * User could easily retrieve the current offset of the writes with the
    `getCount` function.
* Add more utility functions in `ShuffleFile` and `TmpShuffleFile`
  interface related to the creation of various kinds of streams.
* Aggregate the logic related to spill from `SplashSorter` and
  `SplashAppendOnlyMap` to `SpilledFile` class.  Add unittests for those
  spill related logic.

This closes GH-43.