### PR TITLE
[GH-45] Stop shuffle manager raises exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.4</version>
+  <version>0.5.5</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -141,10 +141,15 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
   /** Shut down this ShuffleManager. */
   override def stop(): Unit = {
     StorageFactoryHolder.onApplicationEnd()
-    if (isDriver && conf.get(SplashOpts.clearShuffleOutput)) {
-      shuffleBlockResolver.cleanup()
+    if (conf.contains("spark.app.id")) {
+      logInfo(s"stop shuffle manager for app ${conf.getAppId}")
+      if (isDriver && conf.get(SplashOpts.clearShuffleOutput)) {
+        shuffleBlockResolver.cleanup()
+      }
+      shuffleBlockResolver.stop()
+    } else {
+      logInfo("app id is not available, app may not start yet.")
     }
-    shuffleBlockResolver.stop()
   }
 
   private def isDriver = {

--- a/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/SplashShuffleManagerTest.scala
@@ -21,6 +21,7 @@
 package org.apache.spark.shuffle
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Fail.fail
 import org.testng.annotations.Test
 
 @Test(groups = Array("UnitTest"))
@@ -28,5 +29,15 @@ class SplashShuffleManagerTest {
   def testVersion(): Unit = {
     val version = SplashShuffleManager.version
     assertThat(version).matches("\\d+\\.\\d+\\.\\d+")
+  }
+
+  def testStopWithoutApp(): Unit = {
+    val shuffleManager = new SplashShuffleManager(TestUtil.confWithKryo)
+    try {
+      shuffleManager.stop()
+    } catch {
+      case e: Exception =>
+        fail(s"should not raise exception", e)
+    }
   }
 }


### PR DESCRIPTION
A `NoSuchElementException` is raised when the Splash shuffle manager
tries to stop itself when the application hasn't started successfully.

The reason is that the shuffle manager tries to retrieve the application
id before the application is initialized.  Fix the issue by check if the app id
exists and skip the data cleanup for the application when it's not
initialized yet.

This closes GH-45.