### PR TITLE
[GH-47] Improve merge sort efficiency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.5.5</version>
+  <version>0.5.6</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/org/apache/spark/shuffle/Algorithm.scala
+++ b/src/main/scala/org/apache/spark/shuffle/Algorithm.scala
@@ -1,0 +1,92 @@
+/*
+ * Modifications copyright (C) 2019 MemVerge Inc.
+ *
+ * Extract the logic related to algorithms from the shuffle manager.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import java.util
+
+import scala.collection.mutable
+
+
+object Algorithm {
+  /**
+   * Put the head of the iterators into a treemap so that we could retrieve
+   * the sorted header in an efficient way.
+   *
+   * The original implementation is using a priority queue to sort the iterators.
+   * This is not efficient especially when the partition size is large.
+   *
+   * The drawback of using a map tree is that it overrides duplicated values.
+   * We use an extra priority queue to deal with those values.
+   *
+   * If the key already exists in the treemap, the value is buffered in a
+   * priority queue.  It will be added back to the treemap when the duplicated
+   * key is removed from the tree map.
+   */
+  def mergeSort[T](
+      iterators: Seq[Iterator[T]],
+      comparator: util.Comparator[T]): Iterator[T] = {
+    type BIterator = BufferedIterator[T]
+
+    val heap = new mutable.PriorityQueue[BIterator]()(new Ordering[BIterator] {
+      // Use the reverse of comparator.compare because PriorityQueue dequeues the max
+      override def compare(x: BIterator, y: BIterator): Int =
+        -comparator.compare(x.head, y.head)
+    })
+
+    val treeMap = new util.TreeMap[T, BIterator](comparator)
+
+    def put(iterator: BIterator): Unit = {
+      val prev = treeMap.put(iterator.head, iterator)
+      if (prev != null) {
+        heap.enqueue(prev)
+      }
+    }
+
+    iterators.filter(_.hasNext).map(_.buffered).foreach(put)
+
+    new Iterator[T] {
+      override def hasNext: Boolean = !treeMap.isEmpty
+
+      override def next(): T = {
+        if (!hasNext) {
+          throw new NoSuchElementException
+        }
+        val entry = treeMap.firstEntry()
+        val value = entry.getValue
+        // do not use map key directly because of hash collision
+        val key = value.head
+
+        treeMap.remove(key)
+        if (heap.nonEmpty && comparator.compare(heap.head.head, key) == 0) {
+          val iteratorWithSameKey = heap.dequeue()
+          treeMap.put(iteratorWithSameKey.head, iteratorWithSameKey)
+        } else if (treeMap.isEmpty && heap.nonEmpty) {
+          val iterator = heap.dequeue()
+          treeMap.put(iterator.head, iterator)
+        }
+
+        value.next()
+        if (value.hasNext) put(value)
+        key
+      }
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/AlgorithmTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/AlgorithmTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Modifications copyright (C) 2019 MemVerge Inc.
+ *
+ * Extract the logic related to algorithms from the shuffle manager.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class AlgorithmTest {
+  def testMergeSort(): Unit = {
+    val size = 100
+    val partitionSize = 10
+    val partitions = (0 until partitionSize).map(n => {
+      (0 to size).filter(_ % partitionSize == n)
+    })
+    val sorted = Algorithm.mergeSort(
+      partitions.map(_.iterator),
+      new Ordering[Int] {
+        override def compare(x: Int, y: Int): Int = x - y
+      })
+
+    assertThat(sorted.toList).isEqualTo(0 to size)
+  }
+
+  def testMergeSortWithDupAtBeginning(): Unit = {
+    val i1 = List(1, 3, 5)
+    val i2 = List(1, 4)
+    val sorted = Algorithm.mergeSort(
+      Seq(i1.iterator, i2.iterator),
+      new Ordering[Int] {
+        override def compare(x: Int, y: Int): Int = x - y
+      })
+    assertThat(sorted.toList).isEqualTo(List(1, 1, 3, 4, 5))
+  }
+
+  def testMergeSortWithDupValue(): Unit = {
+    val i1 = List(1, 3, 5, 7)
+    val i2 = List(2, 3)
+    val i3 = List(7)
+    val i4 = List(5)
+    val sorted = Algorithm.mergeSort(
+      Seq(i1.iterator, i2.iterator, i3.iterator, i4.iterator),
+      new Ordering[Int] {
+        override def compare(x: Int, y: Int): Int = x - y
+      })
+    assertThat(sorted.toList).isEqualTo(List(1, 2, 3, 3, 5, 5, 7, 7))
+  }
+
+  def testMergeSortWithSameHashCode(): Unit = {
+    val i1 = List("Aa", "BB", "to")
+    val i2 = List( "v1")
+    val sorted = Algorithm.mergeSort(
+      Seq(i1.iterator, i2.iterator),
+      new Ordering[String] {
+        override def compare(x: String, y: String): Int = x.hashCode - y.hashCode
+      })
+    assertThat(sorted.toList).isEqualTo(List("Aa", "BB", "to", "v1"))
+  }
+
+  @Test(enabled = false)
+  def testMergeSortPerformance(): Unit = {
+    val size = 10000000
+    val partitionSize = 500
+    val partitions = (0 until partitionSize).map(n => {
+      (0 to size).filter(_ % partitionSize == n)
+    })
+
+    TestUtil.time {
+      val sorted = Algorithm.mergeSort(
+        partitions.map(_.iterator),
+        new Ordering[Int] {
+          override def compare(x: Int, y: Int): Int = x - y
+        })
+
+      assertThat(sorted.next) isEqualTo 0
+      assertThat(sorted.toStream.last) isEqualTo size
+    }(50)
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
+++ b/src/test/scala/org/apache/spark/shuffle/TestUtil.scala
@@ -193,6 +193,29 @@ object TestUtil {
   def getSparkConfArray: Array[SparkConf] = {
     Array(confWithKryo, confWithoutKryo)
   }
+
+  def time[R](block: => Unit)(implicit repeats: Int = 1): Unit = {
+    val timeInMillis = (0 to repeats).map { i =>
+      val t0 = System.nanoTime()
+      block
+      val t1 = System.nanoTime()
+      val millis = (t1 - t0) / 1000 / 1000
+      println(s"Run $i Elapsed time: $millis ms")
+      millis
+    }.tail
+    logSummary(timeInMillis)
+  }
+
+  private def logSummary(timeInMillis: Seq[Long]): Unit = {
+    val length = timeInMillis.size
+    val total = timeInMillis.sum
+    println(s"Summary: " +
+        s"runs: $length, " +
+        s"avg: ${total / length}, " +
+        s"max: ${timeInMillis.max}, " +
+        s"min: ${timeInMillis.min}, " +
+        s"sum: $total")
+  }
 }
 
 /**


### PR DESCRIPTION
Replace the `PriorityQueue` with a `TreeMap` which could in theory
improve the sort efficiency from O(N) to O(logN).  Keep a
`PriorityQueue` in the new implementation to deal with the entries with
the same hash key.

Here are the micro-benchmark results on the dev machine.

* item size: 10000000, partitions: 200
  * TreeMap       - runs: 50, avg: 1917, max: 5208, min: 1018, sum: 95864
  * PriorityQueue - runs: 50, avg: 2581, max: 5304, min: 1924, sum: 129072
* item size: 10000000, partitions: 500
  * TreeMap       - runs: 50, avg: 1788, max: 3832, min: 1253, sum: 89403
  * PriorityQueue - runs: 50, avg: 6631, max: 8191, min: 5637, sum: 331550

Other changes:
* Clean the code related to `MapStatus` to avoid sending a null
`MapStatus` back to the scheduler.