### PR TITLE
[GH-49] Shuffle performance tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We want to address these issues in this shuffle manager.
 * [Build](#build)
 * [Options](#options)
 * [Plugin Development](#plugin-development)
+* [Shuffle Performance Tool](#shuffle-performance-tool)
 
 ---
 
@@ -168,3 +169,70 @@ spark.shuffle.splash.folder /your/share/folder
 ```
 * Make sure that all your Spark nodes can access the shared folder you specified in the configuration file.
 * Run some sample Spark applications and you should be able to observe that the application folder is created in a shared folder.
+
+## Shuffle Performance Tool
+
+Use this tool to verify the performance of the storage plugin.  Users could
+also use this tool to compare different storage plugin implementations or find
+the regressions of the storage plugin.
+
+Note that this tool bases on the storage interface.  It does not require a Spark
+environment.
+
+It writes the shuffle output and read them with configured arguments.  See the
+configuration details below:
+
+* `-h` or `--help`: display the usage
+* `-f` or `--factory`: specify the name of the storage factory
+* `-i` or `--shuffleId`: the test shuffle ID, default to 1
+* `-t` or `--tasks`: the number of concurrent tasks, default to 5
+* `-m` or `--mappers`: the number of mappers, default to 10
+* `-r` or `--reducers`: the number of reducers, default to 10
+* `-d` or `--data`: the number of data blocks, default to 1K
+* `-b` or `--blockSize`: the block/buffer size of each data block,
+  default to 256K
+* `-o` or `--overwrite`: overwrite existing outputs
+
+Sample command:
+```
+java -cp target/splash-shaded.jar com.memverge.splash.ShufflePerfTool 
+-d 64 -m 200 -r 200 -t 8 -o
+```
+
+Sample output
+```
+overwrite, removing existing shuffle for shuffleTest-1                                        
+==========================================                                                    
+Writing 200 shuffle with 8 threads: 100% (200/200)                                            
+Write shuffle data completed in 7440 milliseconds                                             
+    Reading index file:  0 ms                                                                 
+    storage factory:     com.memverge.splash.shared.SharedFSFactory                           
+    shuffle folder:      \tmp\splash\shuffleTest-1\shuffle 
+    number of mappers:   200                                                                  
+    number of reducers:  200                                                                  
+    total shuffle size:  3GB                                                                  
+    bytes written:       3GB                                                                  
+    bytes read:          0B                                                                   
+    number of blocks:    64                                                                   
+    blocks size:         256KB                                                                
+    partition size:      81KB                                                                 
+    concurrent tasks:    8                                                                    
+    bandwidth:           430MB/s                                                              
+                                                                                              
+==========================================                                                    
+Reading 40000 partitions with 8 threads   100% (40000/40000)                                   
+Read shuffle data completed in 35525 milliseconds                                             
+    Reading index file:  15907 ms                                                             
+    storage factory:     com.memverge.splash.shared.SharedFSFactory                           
+    shuffle folder:      \tmp\splash\shuffleTest-1\shuffle 
+    number of mappers:   200                                                                  
+    number of reducers:  200                                                                  
+    total shuffle size:  3GB                                                                  
+    bytes written:       3GB                                                                  
+    bytes read:          3GB                                                                  
+    number of blocks:    64                                                                   
+    blocks size:         256KB                                                                
+    partition size:      81KB                                                                 
+    concurrent tasks:    8                                                                    
+    bandwidth:           90MB/s                                                               
+```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>
@@ -113,14 +113,12 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
-      <scope>provided</scope>
     </dependency>
     <!-- hdfs integration dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -132,7 +130,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -144,7 +141,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.compat.version}</artifactId>
       <version>${spark.version}</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/src/main/java/com/memverge/splash/StorageFactoryHolder.java
+++ b/src/main/java/com/memverge/splash/StorageFactoryHolder.java
@@ -44,6 +44,13 @@ public class StorageFactoryHolder {
 
   private int bufferSize = 32 * 1024;
 
+  public static void setDefaultFactoryName(String factoryName) {
+    INSTANCE.defaultFactoryName = factoryName;
+  }
+
+  private String defaultFactoryName =
+      SplashOpts.storageFactoryName().defaultValueString();
+
   private SparkConf conf = null;
 
   public static void setSparkConf(SparkConf sparkConf) {
@@ -63,7 +70,7 @@ public class StorageFactoryHolder {
           if (conf != null) {
             clzName = conf.get(SplashOpts.storageFactoryName());
           } else {
-            clzName = SplashOpts.storageFactoryName().defaultValueString();
+            clzName = defaultFactoryName;
           }
           factory = initFactory(clzName);
         }

--- a/src/main/java/com/memverge/splash/shared/SharedFSShuffleFile.java
+++ b/src/main/java/com/memverge/splash/shared/SharedFSShuffleFile.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.val;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,18 @@ public class SharedFSShuffleFile implements ShuffleFile {
   @Override
   public boolean delete() {
     log.debug("delete file {}", getPath());
-    return file.delete();
+    boolean success = true;
+    try {
+      if (file.isDirectory()) {
+        FileUtils.deleteDirectory(file);
+      } else {
+        FileUtils.forceDelete(file);
+      }
+    } catch (IOException e) {
+      log.error("delete {} failed.", getPath(), e);
+      success = false;
+    }
+    return success;
   }
 
   @Override

--- a/src/main/scala/com/memverge/splash/ShufflePerfTool.scala
+++ b/src/main/scala/com/memverge/splash/ShufflePerfTool.scala
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash
+
+import java.io._
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{CountDownLatch, Executors}
+
+import org.apache.commons.cli.{DefaultParser, HelpFormatter, MissingOptionException, Options, ParseException, UnrecognizedOptionException}
+import org.apache.spark.SparkException
+import org.apache.spark.network.util.LimitedInputStream
+import org.apache.spark.shuffle.{SplashOpts, SplashUtils}
+import org.apache.spark.storage.ShuffleBlockId
+
+import scala.util.Random
+
+object ShufflePerfTool {
+  private lazy val options = initOptions()
+
+  private[splash] def parse(args: Array[String]): Either[String, ShuffleToolOption] = {
+    val className = "DMOShufflePerfTool"
+    val parser = new DefaultParser()
+    try {
+      val cmd = parser.parse(options, args)
+      if (cmd.hasOption("h")) {
+        new HelpFormatter().printHelp(className, options)
+        Left("")
+      } else {
+        Right(ShuffleToolOption(
+          cmd.getOptionValue("f", SplashOpts.storageFactoryName.defaultValueString),
+          Integer.parseInt(cmd.getOptionValue("i", "1")),
+          Integer.parseInt(cmd.getOptionValue("t", "5")),
+          Integer.parseInt(cmd.getOptionValue("m", "10")),
+          Integer.parseInt(cmd.getOptionValue("r", "10")),
+          Integer.parseInt(cmd.getOptionValue("d", "1024")),
+          Integer.parseInt(cmd.getOptionValue("b", "262144")),
+          overwrite = cmd.hasOption("o")))
+      }
+    } catch {
+      case e@(_: UnrecognizedOptionException | _: MissingOptionException) =>
+        Left(e.getMessage)
+      case e: NumberFormatException =>
+        Left(s"invalid integer received.  ${e.getMessage}")
+      case e: ParseException =>
+        Left(s"parse error: ${e.getMessage}")
+    }
+  }
+
+  private def initOptions(): Options = {
+    val options = new Options()
+    options.addOption("h", "help", false, "display help message")
+    options.addOption("f", "factory", true, "Storage factory name")
+    options.addOption("i", "shuffleId", true, "shuffle ID")
+    options.addOption("t", "tasks", true, "# of concurrent tasks")
+    options.addOption("m", "mappers", true, "# of mappers")
+    options.addOption("r", "reducers", true, "# of reducers")
+    options.addOption("d", "data", true, "# of data blocks")
+    options.addOption("b", "blockSize", true, "block/buffer size")
+    options.addOption("o", "overwrite", false, "overwrite existing outputs")
+    options
+  }
+
+
+  case class ShuffleToolOption(
+      factoryName: String,
+      shuffleId: Int,
+      tasks: Int,
+      mappers: Int,
+      reducers: Int,
+      dataBlocks: Int,
+      blockSize: Int,
+      readBufferSize: Int = 256 * 1024,
+      overwrite: Boolean) {
+
+    StorageFactoryHolder.setDefaultFactoryName(factoryName)
+
+    private val appId = s"shuffleTest-$shuffleId"
+    private val shuffleSize: Long = dataBlocks * blockSize
+    private val partitionSize = shuffleSize / reducers
+    private val totalShuffleSize = shuffleSize * mappers
+    private val factory = StorageFactoryHolder.getFactory
+
+    private val bytesWritten = new AtomicLong(0)
+    private val bytesRead = new AtomicLong(0)
+    private val totalTimeReadIndex = new AtomicLong(0)
+    private var latestProgress = ""
+
+    private def shuffleFolder = factory.getShuffleFolder(appId)
+
+    def writeShuffle(): String = {
+      if (overwrite) {
+        println(s"overwrite, removing existing shuffle for $appId")
+        factory.cleanShuffle(appId)
+      }
+
+      val start = System.nanoTime()
+      print(
+        s"""|==========================================
+            |Writing $mappers shuffle with $tasks threads:""".stripMargin)
+      printProgress(0, mappers)
+      val pool = Executors.newFixedThreadPool(tasks)
+      val done = new CountDownLatch(mappers)
+      (0 until mappers).foreach(mapperId => {
+        pool.submit(new Runnable {
+          override def run(): Unit = {
+            try {
+              writeDataFile(shuffleId, mapperId)
+              writeIndexFile(shuffleId, mapperId)
+            } catch {
+              case e: Exception =>
+                println(s"write ${shuffleId}_$mapperId failed, ${e.getMessage}")
+            } finally {
+              printProgress((mappers - done.getCount + 1).intValue, mappers)
+              done.countDown()
+            }
+          }
+        })
+      })
+      pool.shutdown()
+
+      done.await()
+      print("\n")
+
+      val duration = Duration.ofNanos(System.nanoTime() - start)
+      getSummaryString("Write shuffle data", duration)
+    }
+
+    private def printProgress(done: Int, total: Int): Unit = {
+      if (done == 0) latestProgress = ""
+      val len = latestProgress.length
+      val goBack = Array.fill(len)("\b").mkString("")
+      val percent = done * 100 / total
+      latestProgress = f" $percent%3d%% ($done/$total)"
+      print(goBack + latestProgress)
+    }
+
+    private def writeIndexFile(shuffleId: Int, mapperId: Int): Unit = {
+      val blockId = ShuffleBlockId(shuffleId, mapperId, 0)
+      val indexFile = factory.makeIndexFile(s"$shuffleFolder/$blockId.index")
+      val partitionSize = shuffleSize / reducers
+      SplashUtils.withResources {
+        new DataOutputStream(
+          new BufferedOutputStream(
+            indexFile.makeOutputStream()))
+      } { os =>
+        (0 to reducers).foreach { i =>
+          os.writeLong(i * partitionSize)
+        }
+        bytesWritten.addAndGet(8 * (reducers + 1))
+      }
+      indexFile.commit()
+    }
+
+    private def writeDataFile(shuffleId: Int, mapperId: Int): Unit = {
+      val blockId = ShuffleBlockId(shuffleId, mapperId, 0)
+      val dataFile = factory.makeDataFile(s"$shuffleFolder/$blockId.data")
+      val rand = new Random
+      val buffer = new Array[Byte](blockSize)
+      SplashUtils.withResources {
+        new DataOutputStream(
+          new BufferedOutputStream(
+            dataFile.makeOutputStream()))
+      } { os =>
+        (0 until dataBlocks).foreach(_ => {
+          rand.nextBytes(buffer)
+          os.write(buffer)
+          bytesWritten.addAndGet(buffer.length)
+        })
+      }
+      dataFile.commit()
+    }
+
+    def readShuffle(): String = {
+      val start = System.nanoTime()
+      val total = mappers * reducers
+      print(
+        s"""|==========================================
+            |Reading $total partitions with $tasks threads:""".stripMargin)
+      printProgress(0, total)
+      val pool = Executors.newFixedThreadPool(tasks)
+      val done = new CountDownLatch(reducers * mappers)
+      (0 until reducers).foreach(r => {
+        (0 until mappers).foreach(m => {
+          pool.submit(new Runnable {
+            override def run(): Unit = {
+              try {
+                val partitionId = ShuffleBlockId(shuffleId, m, r)
+                getPartitionIS(partitionId) match {
+                  case Some(is) =>
+                    val toRead = is.available()
+                    val buffer = new Array[Byte](readBufferSize)
+                    (0 to toRead / buffer.length).foreach { _ =>
+                      bytesRead.addAndGet(is.read(buffer))
+                    }
+
+                  case None =>
+                    throw new SparkException(s"read $partitionId failed.")
+                }
+              } catch {
+                case e: Exception =>
+                  println(s"read shuffle_${shuffleId}_${m}_$r failed, ${e.getMessage}")
+              } finally {
+                printProgress((total - done.getCount + 1).intValue, total)
+                done.countDown()
+              }
+            }
+          })
+        })
+      })
+      pool.shutdown()
+      done.await()
+      print("\n")
+
+      val duration = Duration.ofNanos(System.nanoTime() - start)
+      getSummaryString("Read shuffle data", duration)
+    }
+
+    private def getSummaryString(op: String, duration: Duration): String = {
+      StorageFactoryHolder.onApplicationEnd()
+      val readIndexTook = Duration.ofNanos(totalTimeReadIndex.get())
+      val bandwidth = totalShuffleSize * 1000 / duration.toMillis
+      s"""|$op completed in ${duration.toMillis} milliseconds
+          |    Reading index file:  ${readIndexTook.toMillis} ms
+          |    storage factory:     ${factory.getClass.getCanonicalName}
+          |    shuffle folder:      $shuffleFolder
+          |    number of mappers:   $mappers
+          |    number of reducers:  $reducers
+          |    total shuffle size:  ${toSizeStr(totalShuffleSize)}
+          |    bytes written:       ${toSizeStr(bytesWritten.get())}
+          |    bytes read:          ${toSizeStr(bytesRead.get())}
+          |    number of blocks:    $dataBlocks
+          |    blocks size:         ${toSizeStr(blockSize)}
+          |    partition size:      ${toSizeStr(partitionSize)}
+          |    concurrent tasks:    $tasks
+          |    bandwidth:           ${toSizeStr(bandwidth)}/s
+          |""".stripMargin
+    }
+
+    private def getPartitionIS(blockId: ShuffleBlockId): Option[InputStream] = {
+      val fileId = ShuffleBlockId(blockId.shuffleId, blockId.mapId, 0)
+      val indexFile = factory.getIndexFile(s"$shuffleFolder/$fileId.index")
+      val dataFile = factory.getDataFile(s"$shuffleFolder/$fileId.data")
+      val start = System.nanoTime()
+      try
+        SplashUtils.withResources {
+          val indexIs = indexFile.makeInputStream()
+          indexIs.skip(blockId.reduceId * 8L)
+          new DataInputStream(new BufferedInputStream(indexIs, 16))
+        } { is =>
+
+          val offset = is.readLong()
+          val nextOffset = is.readLong()
+
+          totalTimeReadIndex.addAndGet(System.nanoTime() - start)
+          bytesRead.addAndGet(8 * 2)
+
+          val dataIs = new LimitedInputStream(dataFile.makeInputStream(), nextOffset)
+          dataIs.skip(offset)
+          Some(new BufferedInputStream(dataIs, readBufferSize))
+        }
+      catch {
+        case _: IOException => None
+      }
+    }
+  }
+
+  private[splash] def execute(args: Array[String]): Unit = {
+    parse(args) match {
+      case Left(errorMsg) =>
+        println(errorMsg)
+      case Right(option) =>
+        StorageFactoryHolder.onApplicationStart()
+        println(option.writeShuffle())
+        println(option.readShuffle())
+        StorageFactoryHolder.onApplicationEnd()
+    }
+  }
+
+  private def toSizeStr(size: Long): String = {
+    val scale = 1024L
+    val kbScale: Long = scale
+    val mbScale: Long = scale * kbScale
+    val gbScale: Long = scale * mbScale
+    val tbScale: Long = scale * gbScale
+    if (size > tbScale) {
+      size / tbScale + "TB"
+    } else if (size > gbScale) {
+      size / gbScale + "GB"
+    } else if (size > mbScale) {
+      size / mbScale + "MB"
+    } else if (size > kbScale) {
+      size / kbScale + "KB"
+    } else {
+      size + "B"
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    execute(args)
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashUtils.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 
 import scala.util.control.NonFatal
 
-private[spark] object SplashUtils extends Logging {
+object SplashUtils extends Logging {
   def withResources[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
     val resource: T = r
     require(resource != null, "resource is null")

--- a/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
+++ b/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
@@ -1,0 +1,32 @@
+package com.memverge.splash
+
+import java.time.Duration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.{BeforeMethod, Test}
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class ShufflePerfToolTest {
+  @BeforeMethod
+  private def beforeMethod(): Unit = {
+    StorageFactoryHolder.getFactory.reset()
+  }
+
+  def testUsage(): Unit = {
+    val ret = ShufflePerfTool.parse(Array("-h"))
+    assertThat(ret.isLeft).isTrue
+  }
+
+  def testWriteReadShuffleWithDefaultConfig(): Unit = {
+    val start = System.nanoTime()
+    ShufflePerfTool.execute(Array("-b", "1024"))
+    val duration = Duration.ofNanos(System.nanoTime() - start)
+    assertThat(duration.toMillis).isLessThan(2000)
+  }
+
+  def testInvalidIntParameter(): Unit = {
+    val ret = ShufflePerfTool.parse(Array("-b", "block"))
+    assertThat(ret.isLeft).isTrue
+    ret.left.map(msg => assertThat(msg).contains("invalid integer"))
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorterTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/sort/SplashUnsafeSorterTest.scala
@@ -26,8 +26,6 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.{AfterMethod, DataProvider, Test}
 
-import scala.collection.mutable
-
 @Test(groups = Array("UnitTest", "IntegrationTest"))
 class SplashUnsafeSorterTest {
   private var sc: SparkContext = _


### PR DESCRIPTION
Create a shuffle performance tool that allows the user to quickly verify
the performance of the storage factory without starting a Spark
application.

Here is the sample command of starting a test with the default
configurations:
```
java -cp splash-shaded.jar com.memverge.splash.ShufflePerfTool
```

You could specify the following options to configure the test:
* `-h` or `--help`: display the usage
* `-f` or `--factory`: specify the name of the storage factory
* `-i` or `--shuffleId`: the test shuffle ID, default to 1
* `-t` or `--tasks`: the number of concurrent tasks, defaults to 5
* `-m` or `--mappers`: the number of mappers, defaults to 10
* `-r` or `--reducers`: the number of reducers, defaults to 10
* `-d` or `--data`: the number of data blocks, defaults to 1K
* `-b` or `--blockSize`: the block/buffer size of each data block,
  default to 256K

Sample command:
```
java -cp target/splash-0.6.1-shaded.jar com.memverge.splash.ShufflePerfTool -d 256 -m 50 -r 50 -t 4 -o
```

Sample output:
```
==========================================
Writing 50 shuffle outputs: 100% (50/50)
Write shuffle data completed in 5029 milliseconds
    storage factory:     com.memverge.splash.shared.SharedFSFactory
    shuffle folder:      \tmp\splash\shuffleTest-1\shuffle
    number of mappers:   50
    number of reducers:  50
    total shuffle size:  3GB
    bytes written:       3GB
    bytes read:          0B
    number of blocks:    256
    blocks size:         262KB
    partition size:      1MB
    concurrent tasks:    4
    bandwidth:           667MB/s

==========================================
Reading 2500 partitions:  100% (2500/2500)
Read shuffle data completed in 1813 milliseconds
    Reading index file:  198 ms
    storage factory:     com.memverge.splash.shared.SharedFSFactory
    shuffle folder:      \tmp\splash\shuffleTest-1\shuffle
    number of mappers:   50
    number of reducers:  50
    total shuffle size:  3GB
    bytes written:       3GB
    bytes read:          3GB
    number of blocks:    256
    blocks size:         262KB
    partition size:      1MB
    concurrent tasks:    4
    bandwidth:           1GB/s
```