### PR TITLE
[GH-51] Cache shuffle index in memory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/java/com/memverge/splash/ShuffleFile.java
+++ b/src/main/java/com/memverge/splash/ShuffleFile.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import lombok.val;
 import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.shuffle.PartitionLoc;
 
 public interface ShuffleFile {
 
@@ -40,6 +41,11 @@ public interface ShuffleFile {
 
   default BufferedInputStream makeBufferedInputStream() {
     return new BufferedInputStream(makeInputStream(), inputStreamBufferSize());
+  }
+
+  default BufferedInputStream makeBufferedInputStreamWithin(
+      PartitionLoc loc) throws IOException {
+    return makeBufferedInputStreamWithin(loc.start(), loc.end());
   }
 
   default BufferedInputStream makeBufferedInputStreamWithin(

--- a/src/main/java/com/memverge/splash/shared/SharedFSShuffleFile.java
+++ b/src/main/java/com/memverge/splash/shared/SharedFSShuffleFile.java
@@ -47,11 +47,9 @@ public class SharedFSShuffleFile implements ShuffleFile {
     log.debug("delete file {}", getPath());
     boolean success = true;
     try {
-      if (file.isDirectory()) {
-        FileUtils.deleteDirectory(file);
-      } else {
-        FileUtils.forceDelete(file);
-      }
+      FileUtils.forceDelete(file);
+    } catch (FileNotFoundException e) {
+      log.info("file to delete {} not found", file.getAbsolutePath());
     } catch (IOException e) {
       log.error("delete {} failed.", getPath(), e);
       success = false;
@@ -90,9 +88,11 @@ public class SharedFSShuffleFile implements ShuffleFile {
     val tgtFile = new File(tgtId);
     val parent = tgtFile.getParentFile();
     if (!parent.exists() && !parent.mkdirs()) {
-      val msg = String.format("create parent folder %s failed",
-          parent.getAbsolutePath());
-      throw new IOException(msg);
+      if (!parent.exists()) {
+        val msg = String.format("create parent folder %s failed",
+            parent.getAbsolutePath());
+        throw new IOException(msg);
+      }
     }
     boolean success = file.renameTo(tgtFile);
     if (success) {

--- a/src/main/scala/org/apache/spark/shuffle/ShuffleCache.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ShuffleCache.scala
@@ -1,0 +1,151 @@
+/*
+ * Modifications copyright (C) 2019 MemVerge Inc.
+ *
+ * Use storage factory to create input/output streams and get file instance.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import java.io.{DataInputStream, EOFException}
+import java.util.concurrent.TimeUnit
+
+import com.memverge.splash.ShuffleFile
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.storage.ShuffleBlockId
+import org.spark_project.guava.cache.{CacheBuilder, CacheLoader, LoadingCache}
+
+import scala.collection.mutable
+
+
+case class ShuffleCache(resolver: SplashShuffleBlockResolver)
+    extends Logging {
+
+  private lazy val shuffleMap = CacheBuilder.newBuilder()
+      .maximumSize(getCacheSize)
+      .expireAfterAccess(1, TimeUnit.MINUTES)
+      .build(new CacheLoader[Int, DataMap] {
+        override def load(shuffleId: Int): DataMap =
+          DataMap(resolver, shuffleId)
+      })
+      .asInstanceOf[LoadingCache[Int, DataMap]]
+
+  def getDataFile(blockId: ShuffleBlockId): ShuffleFile =
+    getDataMap(blockId.shuffleId).getDataFile(blockId)
+
+  def getPartitionLoc(blockId: ShuffleBlockId): Option[PartitionLoc] = {
+    try {
+      val shuffleId = blockId.shuffleId
+      val dataMap = getDataMap(shuffleId)
+      dataMap.getPartitionLoc(blockId)
+    } catch {
+      case e: Exception =>
+        logError(s"error reading partition location for $blockId", e)
+        None
+    }
+  }
+
+  def invalidateCache(shuffleId: Int): Unit = {
+    shuffleMap.get(shuffleId).invalidate()
+    shuffleMap.invalidate(shuffleId)
+  }
+
+  def invalidateAll(): Unit = shuffleMap.invalidateAll()
+
+  private def getDataMap(shuffleId: Int) = shuffleMap.get(shuffleId)
+
+  private def getCacheSize: Int = {
+    val env = SparkEnv.get
+    val cacheSizeOpt = SplashOpts.shuffleCacheSize
+    val invalidSize = -1
+    var cacheSize: Int = invalidSize
+    if (env != null) {
+      val conf = env.conf
+      if (conf != null) {
+        cacheSize = conf.get(cacheSizeOpt)
+      }
+    }
+    if (cacheSize == invalidSize) {
+      cacheSize = cacheSizeOpt.defaultValue.get
+    }
+    logInfo(s"initialize shuffle cache with max size $cacheSize")
+    cacheSize
+  }
+}
+
+
+case class DataMap(resolver: SplashShuffleBlockResolver, shuffleId: Int)
+    extends Logging {
+  private val mapper2Data = CacheBuilder.newBuilder()
+      .build(new CacheLoader[Int, Option[Array[Long]]] {
+        override def load(mapId: Int): Option[Array[Long]] = {
+          val blockId = ShuffleBlockId(shuffleId, mapId, resolver.NOOP_REDUCE_ID)
+          initOffsetArray(blockId)
+        }
+      })
+      .asInstanceOf[LoadingCache[Int, Option[Array[Long]]]]
+
+  private val blockId2DataFile = CacheBuilder.newBuilder()
+      .build(new CacheLoader[(Int, Int), ShuffleFile] {
+        override def load(index: (Int, Int)): ShuffleFile = {
+          logDebug("get block data for " +
+              s"shuffle ${index._1} map ${index._2}")
+          resolver.getDataFile(index._1, index._2)
+        }
+      })
+      .asInstanceOf[LoadingCache[(Int, Int), ShuffleFile]]
+
+  def getDataFile(blockId: ShuffleBlockId): ShuffleFile = {
+    val index = (blockId.shuffleId, blockId.mapId)
+    blockId2DataFile.get(index)
+  }
+
+  def getPartitionLoc(blockId: ShuffleBlockId): Option[PartitionLoc] = {
+    val offsetArrayOpt = mapper2Data.get(blockId.mapId)
+    val reducerId = blockId.reduceId
+    offsetArrayOpt.map(arr => PartitionLoc(arr(reducerId), arr(reducerId + 1)))
+  }
+
+  private def initOffsetArray(blockId: ShuffleBlockId): Option[Array[Long]] = {
+    val indexFile = resolver.getIndexFile(blockId)
+    val ret = mutable.ArrayBuffer[Long]()
+    try {
+      SplashUtils.withResources {
+        logDebug(s"read shuffle index ${indexFile.getPath}")
+        new DataInputStream(indexFile.makeBufferedInputStream())
+      }(stream =>
+        try {
+          while (true) {
+            ret += stream.readLong()
+          }
+        } catch {
+          case _: EOFException => // do nothing
+        }
+      )
+      Some(ret.toArray)
+    } catch {
+      case e: Exception =>
+        logError(s"read index file ${indexFile.getPath} failed", e)
+        None
+    }
+  }
+
+  def invalidate(): Unit = {
+    mapper2Data.invalidateAll()
+    blockId2DataFile.invalidateAll()
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/SplashOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashOpts.scala
@@ -42,6 +42,12 @@ object SplashOpts {
         .booleanConf
         .createWithDefault(true)
 
+  lazy val shuffleCacheSize: ConfigEntry[Int] =
+    ConfigBuilder("spark.shuffle.splash.cacheSize")
+        .doc("max number of shuffles to cache.")
+        .intConf
+        .createWithDefault(10)
+
   lazy val spillCheckInterval: ConfigEntry[Int] =
     createIfNotExists("spark.shuffle.spill.checkInterval", builder => {
       builder.intConf.createWithDefault(1000)

--- a/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/SplashShuffleManager.scala
@@ -128,6 +128,7 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
    */
   override def unregisterShuffle(shuffleId: Int): Boolean = {
     logInfo(s"unregister shuffle $shuffleId of app ${conf.getAppId}")
+    shuffleBlockResolver.invalidateShuffleCache(shuffleId)
     Option(numMapsForShuffle.remove(shuffleId)).foreach { numMaps =>
       if (isDriver && conf.get(SplashOpts.clearShuffleOutput)) {
         logInfo(s"remove shuffle $shuffleId data with $numMaps mappers.")
@@ -144,10 +145,10 @@ class SplashShuffleManager(conf: SparkConf) extends ShuffleManager with Logging 
     StorageFactoryHolder.onApplicationEnd()
     if (conf.contains("spark.app.id")) {
       logInfo(s"stop shuffle manager for app ${conf.getAppId}")
+      shuffleBlockResolver.stop()
       if (isDriver && conf.get(SplashOpts.clearShuffleOutput)) {
         shuffleBlockResolver.cleanup()
       }
-      shuffleBlockResolver.stop()
     } else {
       logInfo("app id is not available, app may not start yet.")
     }

--- a/src/test/java/com/memverge/splash/ManualCloseOutputStreamTest.java
+++ b/src/test/java/com/memverge/splash/ManualCloseOutputStreamTest.java
@@ -74,6 +74,7 @@ public class ManualCloseOutputStreamTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public void testMetrics() throws IOException {
     val metrics = new ShuffleWriteMetrics();
     val file = factory.makeSpillFile();

--- a/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
+++ b/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
@@ -3,14 +3,15 @@ package com.memverge.splash
 import java.time.Duration
 
 import org.assertj.core.api.Assertions.assertThat
-import org.testng.annotations.{BeforeMethod, Test}
+import org.testng.annotations.{AfterMethod, BeforeMethod, Test}
 
 @Test(groups = Array("UnitTest", "IntegrationTest"))
 class ShufflePerfToolTest {
   @BeforeMethod
-  private def beforeMethod(): Unit = {
-    StorageFactoryHolder.getFactory.reset()
-  }
+  private def beforeMethod(): Unit = afterMethod
+
+  @AfterMethod
+  private def afterMethod(): Unit = StorageFactoryHolder.getFactory.reset()
 
   def testUsage(): Unit = {
     val ret = ShufflePerfTool.parse(Array("-h"))
@@ -18,10 +19,15 @@ class ShufflePerfToolTest {
   }
 
   def testWriteReadShuffleWithDefaultConfig(): Unit = {
-    val start = System.nanoTime()
+    val start1 = System.nanoTime()
     ShufflePerfTool.execute(Array("-b", "1024"))
-    val duration = Duration.ofNanos(System.nanoTime() - start)
-    assertThat(duration.toMillis).isLessThan(2000)
+    val duration1 = Duration.ofNanos(System.nanoTime() - start1)
+    assertThat(duration1.toMillis).isLessThan(2000)
+
+    val start2 = System.nanoTime()
+    ShufflePerfTool.execute(Array("-b", "1024", "-ro"))
+    val duration2 = Duration.ofNanos(System.nanoTime() - start2)
+    assertThat(duration2.toMillis).isLessThan(duration1.toMillis)
   }
 
   def testInvalidIntParameter(): Unit = {

--- a/src/test/scala/org/apache/spark/shuffle/ShuffleCacheTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/ShuffleCacheTest.scala
@@ -1,0 +1,121 @@
+/*
+ * Modifications copyright (C) 2019 MemVerge Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import com.memverge.splash.StorageFactoryHolder
+import org.apache.spark.storage.ShuffleBlockId
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.{AfterMethod, BeforeMethod, Test}
+
+
+@Test(groups = Array("UnitTest", "IntegrationTest"))
+class ShuffleCacheTest {
+  private val shuffleId = 2
+  private val resolver = new SplashShuffleBlockResolver("shuffleCacheTest")
+  private var shuffleCache: ShuffleCache = _
+
+  @BeforeMethod
+  private def beforeMethod(): Unit = shuffleCache = ShuffleCache(resolver)
+
+  @AfterMethod
+  private def afterMethod(): Unit = {
+    shuffleCache.invalidateAll()
+    StorageFactoryHolder.getFactory.reset()
+  }
+
+  private def writeTestData(shuffleId: Int, mapId: Int): Unit = {
+    val length = Array(10L, 0L, 20L)
+    val dataTmp = resolver.getDataTmpFile(shuffleId, mapId)
+    resolver.writeData(dataTmp, (1 to 30).map(_.toByte).toArray)
+    resolver.writeIndexFileAndCommit(shuffleId, mapId, length, dataTmp)
+  }
+
+  def testCacheIndexFile(): Unit = {
+    val mapId = 0
+    writeTestData(shuffleId, mapId)
+
+    val indexFile = resolver.getIndexFile(shuffleId, mapId)
+    assertThat(indexFile.exists()) isTrue()
+
+    val blockId = ShuffleBlockId(shuffleId, mapId, 2)
+    val expected = Some(PartitionLoc(10, 30))
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(expected)
+
+    indexFile.delete()
+    assertThat(indexFile.exists()) isFalse()
+
+    // make sure we could still read the location from cache
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(expected)
+  }
+
+  def testInvalidateSpecifiedShuffle(): Unit = {
+    val mapId = 1
+    writeTestData(shuffleId, mapId)
+    writeTestData(shuffleId + 1, mapId)
+    val expected = Some(PartitionLoc(10, 30))
+
+    val blockId = ShuffleBlockId(shuffleId, mapId, 2)
+    val blockId1 = ShuffleBlockId(shuffleId + 1, mapId, 2)
+    // make sure we cache the value
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(expected)
+    assertThat(shuffleCache.getPartitionLoc(blockId1)).isEqualTo(expected)
+
+    resolver.getIndexFile(shuffleId, mapId).delete()
+    resolver.getIndexFile(shuffleId + 1, mapId).delete()
+    shuffleCache.invalidateCache(shuffleId)
+
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(None)
+    assertThat(shuffleCache.getPartitionLoc(blockId1)).isEqualTo(expected)
+  }
+
+  def testInvalidateAllCache(): Unit = {
+    val mapId = 2
+    writeTestData(shuffleId, mapId)
+    val expected = Some(PartitionLoc(10, 30))
+
+    val blockId = ShuffleBlockId(shuffleId, mapId, 2)
+    // make sure we cache the value
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(expected)
+    resolver.getIndexFile(shuffleId, mapId).delete()
+    shuffleCache.invalidateAll()
+
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(None)
+  }
+
+  def testCacheDataFileReference(): Unit = {
+    val mapId = 3
+    writeTestData(shuffleId, mapId)
+    val blockId = ShuffleBlockId(shuffleId, mapId, 1)
+
+    val data0 = shuffleCache.getDataFile(blockId)
+    val data1 = shuffleCache.getDataFile(blockId)
+    assertThat(data0).isEqualTo(data1)
+
+    shuffleCache.invalidateCache(shuffleId)
+    val data2 = shuffleCache.getDataFile(blockId)
+    assertThat(data0).isNotEqualTo(data2)
+  }
+
+  def testInvalidPartitionNumber(): Unit = {
+    val mapId = 4
+    writeTestData(shuffleId, mapId)
+    val blockId = ShuffleBlockId(shuffleId, mapId, 100)
+    assertThat(shuffleCache.getPartitionLoc(blockId)).isEqualTo(None)
+  }
+}


### PR DESCRIPTION
Cache the shuffle index file and data file reference in memory to speed
up the retrieving of data partition locations.

This enhancement would greatly reduce the call for retrieving index from
the index file.

Previously, we need to read the index file whenever we read a new
partition.  With the cache, we will only read the index file once for
each executor.

Add a new option `spark.shuffle.splash.cacheSize` to control the
number of shuffles that has index cache.  The default value is 10.

Here is some performance benchmark between 0.6.0 and 0.6.2
I use IBM's TPC-DS and choose some shuffle heavy queries.

  | 0.6.0 | 0.6.2 | Δ
-- | -- | -- | --
query04 | 157.5 | 93.41 | 64.09
query06 | 57.97 | 48.66 | 9.31
query11 | 109.95 | 74.88 | 35.07
query12 | 34.32 | 37.36 | -3.04
query13 | 25.98 | 25.5 | 0.48
query15 | 28.78 | 28.31 | 0.47
query16 | 31.08 | 30.29 | 0.79
query17 | 46.74 | 42.43 | 4.31
query23 | 75.95 | 70.11 | 5.84
query23 | 47.93 | 41.83 | 6.1
query24 | 51.61 | 46.99 | 4.62
query24 | 20.35 | 19.02 | 1.33
query25 | 40.95 | 41.43 | -0.48
query29 | 42.55 | 40.54 | 2.01
query45 | 28.06 | 28.02 | 0.04
query49 | 48.92 | 42.18 | 6.74
query50 | 34.89 | 30.78 | 4.11
query51 | 164.93 | 115.57 | 49.36
query54 | 51.08 | 51.09 | -0.01
query64 | 73.93 | 68.69 | 5.24
query65 | 43.5 | 46.16 | -2.66
query67 | 45.14 | 45.85 | -0.71
query72 | 56.81 | 55.74 | 1.07
query74 | 93.9 | 76.83 | 17.07
query75 | 101.57 | 79.99 | 21.58
query78 | 59.74 | 56.51 | 3.23
query80 | 52.51 | 56.96 | -4.45
query93 | 30.07 | 28.94 | 1.13
query98 | 43.63 | 42.65 | 0.98
  |   |   |  
Total | 1700.34 | 1466.72 | 233.62

