### PR TITLE
[GH-57] Shuffle tool output is not precise

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.6.3</version>
+  <version>0.6.4</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>

--- a/src/main/scala/com/memverge/splash/ShufflePerfTool.scala
+++ b/src/main/scala/com/memverge/splash/ShufflePerfTool.scala
@@ -296,19 +296,23 @@ object ShufflePerfTool {
     }
   }
 
-  private def toSizeStr(scale: Long)(size: Long): String = {
+  private def toSizeStr(scale: Long)(size: Long): String =
+    toSizeStrDouble(scale)(size.doubleValue())
+
+  private[splash] def toSizeStrDouble(scale: Long)(size: Double): String = {
     val kbScale: Long = scale
     val mbScale: Long = scale * kbScale
     val gbScale: Long = scale * mbScale
     val tbScale: Long = scale * gbScale
+    val dSize = size.doubleValue()
     if (size > tbScale) {
-      size / tbScale + "T"
+      "%.2fT".format(dSize / tbScale)
     } else if (size > gbScale) {
-      size / gbScale + "G"
+      "%.2fG".format(dSize / gbScale)
     } else if (size > mbScale) {
-      size / mbScale + "M"
+      "%.2fM".format(dSize / mbScale)
     } else if (size > kbScale) {
-      size / kbScale + "K"
+      "%.2fK".format(dSize / kbScale)
     } else {
       size + ""
     }

--- a/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
+++ b/src/test/scala/com/memverge/splash/ShufflePerfToolTest.scala
@@ -8,7 +8,7 @@ import org.testng.annotations.{AfterMethod, BeforeMethod, Test}
 @Test(groups = Array("UnitTest", "IntegrationTest"))
 class ShufflePerfToolTest {
   @BeforeMethod
-  private def beforeMethod(): Unit = afterMethod
+  private def beforeMethod(): Unit = afterMethod()
 
   @AfterMethod
   private def afterMethod(): Unit = StorageFactoryHolder.getFactory.reset()
@@ -34,5 +34,14 @@ class ShufflePerfToolTest {
     val ret = ShufflePerfTool.parse(Array("-b", "block"))
     assertThat(ret.isLeft).isTrue
     ret.left.map(msg => assertThat(msg).contains("invalid integer"))
+  }
+
+  def testToSizeStr(): Unit = {
+    val scale = ShufflePerfTool.toSizeStrDouble(1000L)(_)
+    assertThat(scale(987)).isEqualTo("987.0")
+    assertThat(scale(512 * 1e3)).isEqualTo("512.00K")
+    assertThat(scale(1010 * 1e3)).isEqualTo("1.01M")
+    assertThat(scale(1237 * 1e6)).isEqualTo("1.24G")
+    assertThat(scale(5678 * 1e9)).isEqualTo("5.68T")
   }
 }


### PR DESCRIPTION
The output of the shuffle performance tool is not precise enough. For example, 1.23GB would only be displayed as 1GB. The output should keep at least two digits for the purpose of tuning and performance comparison.

Update the output of the shuffle tool to show at least two digits.