### PR TITLE
[GH-64] Add support for HDFS compliant file systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.memverge</groupId>
   <artifactId>splash</artifactId>
-  <version>0.7.0</version>
+  <version>0.8.0</version>
   <name>splash</name>
   <description>A shuffle manager that contains a storage interface.</description>
   <url>https://github.com/MemVerge/splash/</url>
@@ -39,11 +39,12 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <hadoop.version>2.7.4</hadoop.version>
-    <spark.version>2.3.2</spark.version>
-    <scala.version>2.11.8</scala.version>
+    <hadoop.version>2.8.5</hadoop.version>
+    <spark.version>2.4.6</spark.version>
+    <scala.version>2.11.12</scala.version>
     <scala.compat.version>2.11</scala.compat.version>
     <jacoco.version>0.8.2</jacoco.version>
+    <jackson.version>2.11.2</jackson.version>
     <logback.version>1.2.3</logback.version>
     <guava.version>15.0</guava.version>
     <test.runner.version>2.22.1</test.runner.version>
@@ -148,6 +149,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
     <!-- start of test dependencies -->
     <dependency>
       <groupId>org.jacoco</groupId>
@@ -185,6 +191,18 @@
       <artifactId>lombok</artifactId>
       <version>1.18.4</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/memverge/splash/dfs/DistributedFSFactory.java
+++ b/src/main/java/com/memverge/splash/dfs/DistributedFSFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash.dfs;
+
+import com.memverge.splash.*;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+public class DistributedFSFactory implements StorageFactory {
+  private final DistributedFSTempFolder tempFolder = DistributedFSTempFolder.getInstance();
+
+  @Override
+  public TmpShuffleFile makeSpillFile() {
+    return DistributedFSTmpShuffleFile.make();
+  }
+
+  @Override
+  public TmpShuffleFile makeDataFile(String path) throws IOException {
+    return DistributedFSTmpShuffleFile.make(getDataFile(path));
+  }
+
+  @Override
+  public TmpShuffleFile makeIndexFile(String path) throws IOException {
+    return DistributedFSTmpShuffleFile.make(new DistributedFSShuffleFile(path));
+  }
+
+  @Override
+  public ShuffleFile getDataFile(String path) {
+    return new DistributedFSShuffleFile(path);
+  }
+
+  @Override
+  public ShuffleFile getIndexFile(String path) {
+    return new DistributedFSShuffleFile(path);
+  }
+
+  @Override
+  public Collection<ShuffleListener> getListeners() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getShuffleFolder(String appId) {
+    return tempFolder.getShufflePath(appId);
+  }
+
+  @Override
+  public int getShuffleFileCount(String appId) {
+    try {
+      return tempFolder.countShuffleFile(appId);
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Override
+  public int getTmpFileCount() throws IOException {
+    return tempFolder.countTmpFile();
+  }
+
+  @Override
+  public void reset() {
+    tempFolder.reset();
+  }
+}

--- a/src/main/java/com/memverge/splash/dfs/DistributedFSShuffleFile.java
+++ b/src/main/java/com/memverge/splash/dfs/DistributedFSShuffleFile.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash.dfs;
+
+import com.google.common.io.Closeables;
+import com.memverge.splash.ShuffleFile;
+import lombok.val;
+import org.apache.hadoop.fs.*;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.SplashOpts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.Optional;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+
+public class DistributedFSShuffleFile implements ShuffleFile {
+
+  private static final Logger log = LoggerFactory.getLogger(DistributedFSShuffleFile.class);
+  private static final String splashFolder;
+  private static final FileContext fileContext;
+
+  static {
+    val sparkConf = Optional
+      .ofNullable(SparkEnv.get())
+      .map(SparkEnv::conf)
+      .orElse(new SparkConf(false));
+    val hadoopConf = FileContextManager.getHadoopConf();
+    splashFolder = sparkConf
+      .get(SplashOpts.localSplashFolder().key(), hadoopConf.get(FS_DEFAULT_NAME_KEY, FS_DEFAULT_NAME_DEFAULT));
+    hadoopConf.set(FS_DEFAULT_NAME_KEY, splashFolder);
+    fileContext = FileContextManager.getOrCreate();
+    log.info("Using file system {} for shuffle", splashFolder);
+  }
+
+  protected Path underlyingFilePath;
+
+  DistributedFSShuffleFile(String path) {
+    this.underlyingFilePath = new Path(splashFolder, path);
+  }
+
+  @Override
+  public long getSize() {
+    long len = 0;
+    try {
+      len = fileContext.getFileStatus(underlyingFilePath).getLen();
+    } catch (IOException ioe) {
+      val msg = String.format("get size failed for %s.", getPath());
+      throw new IllegalArgumentException(msg, ioe);
+    }
+    return len;
+  }
+
+  @Override
+  public boolean delete() throws IOException {
+    return fileContext.delete(underlyingFilePath, true);
+  }
+
+  @Override
+  public boolean exists() throws IOException {
+    return fileContext.util().exists(underlyingFilePath);
+  }
+
+  @Override
+  public String getPath() {
+    return underlyingFilePath.toString();
+  }
+
+  @Override
+  public InputStream makeInputStream() {
+    InputStream distFileStream;
+    try {
+      distFileStream = fileContext.open(underlyingFilePath);
+      log.debug("Create input stream for {}.", getPath());
+    } catch (IOException e) {
+      val msg = String.format("Unable to create input stream for %s.", getPath());
+      throw new IllegalArgumentException(msg, e);
+    }
+    return distFileStream;
+  }
+
+  void rename(String tgtId) throws IOException {
+    val destPath = new Path(URI.create(tgtId));
+    val createFlags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
+    Closeables.close(fileContext.create(destPath, createFlags, Options.CreateOpts.createParent()), false);
+    fileContext.rename(underlyingFilePath, destPath, Options.Rename.OVERWRITE);
+  }
+
+  protected FileContext getFileContext() {
+    return fileContext;
+  }
+}

--- a/src/main/java/com/memverge/splash/dfs/DistributedFSTempFolder.java
+++ b/src/main/java/com/memverge/splash/dfs/DistributedFSTempFolder.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash.dfs;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.SplashOpts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class DistributedFSTempFolder {
+  private static final Logger log = LoggerFactory.getLogger(DistributedFSTempFolder.class);
+  private static final DistributedFSTempFolder INSTANCE = new DistributedFSTempFolder();
+  private static final FileContext fileContext = FileContextManager.getOrCreate();
+
+  public static DistributedFSTempFolder getInstance() {
+    return INSTANCE;
+  }
+
+  private DistributedFSTempFolder() {
+  }
+
+  private String getSplashPath() {
+    String folder = null;
+    SparkEnv env = SparkEnv.get();
+    if (env != null) {
+      SparkConf conf = env.conf();
+      if (conf != null) {
+        folder = conf.get(SplashOpts.localSplashFolder());
+      }
+    }
+    if (folder == null) {
+      String tmpFolder = System.getProperty("java.io.tmpdir");
+      folder = String.format("%s/%s/splash", tmpFolder, getUser());
+    }
+    return folder;
+  }
+
+  private String getUser() {
+    String user = System.getProperty("user.name");
+    return StringUtils.isEmpty(user) ? "unknown" : user;
+  }
+
+  public String getTmpPath() {
+    Path path = new Path(getSplashPath(), "tmp");
+    ensureFolderExists(path);
+    return path.toString();
+  }
+
+  public String getShufflePath(String appId) {
+    Path path = new Path(String.format("%s/%s/shuffle", getSplashPath(), appId));
+    ensureFolderExists(path);
+    return path.toString();
+  }
+
+  public int countShuffleFile(String appId) throws IOException {
+    Path file = new Path(getShufflePath(appId));
+    FileStatus[] fileStatuses = Optional.ofNullable(fileContext.util().listStatus(file)).orElse(new FileStatus[]{});
+    return Long.valueOf(Arrays.stream(fileStatuses).map(FileStatus::getLen).mapToLong(Long::longValue).sum()).intValue();
+  }
+
+  public int countTmpFile() throws IOException {
+    return Objects.requireNonNull(fileContext.util().listStatus(new Path(getTmpPath()))).length;
+  }
+
+  public void reset() {
+    String path = getSplashPath();
+    try {
+      fileContext.delete(new Path(path), true);
+    } catch (FileNotFoundException e) {
+      log.debug("{} not exists.  do nothing.", path);
+    } catch (IOException e) {
+      log.error("failed to clean up local splash folder: {}", path, e);
+    }
+  }
+
+  private void ensureFolderExists(Path path) {
+    try {
+      Path folder;
+      if (fileContext.util().exists(path)) {
+        FileStatus[] statuses = fileContext.util().listStatus(path);
+        List<FileStatus> file = Arrays.stream(statuses).filter(fs -> fs.getPath().equals(path)).collect(Collectors.toList());
+        if (file.isEmpty() || file.get(0).isFile()) {
+          folder = path.getParent();
+        } else {
+          folder = file.get(0).getPath();
+        }
+      } else {
+        folder = path;
+      }
+      fileContext.mkdir(folder, null, true);
+      log.info("Create folder {}", path.getParent());
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+}

--- a/src/main/java/com/memverge/splash/dfs/DistributedFSTmpShuffleFile.java
+++ b/src/main/java/com/memverge/splash/dfs/DistributedFSTmpShuffleFile.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2018 MemVerge Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.memverge.splash.dfs;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closeables;
+import com.memverge.splash.ShuffleFile;
+import com.memverge.splash.TmpShuffleFile;
+import lombok.val;
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.shuffle.ShuffleSpillInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.EnumSet;
+import java.util.UUID;
+
+public class DistributedFSTmpShuffleFile extends DistributedFSShuffleFile implements TmpShuffleFile {
+
+  private static final Logger log = LoggerFactory.getLogger(DistributedFSTmpShuffleFile.class);
+  private static final DistributedFSTempFolder folder = DistributedFSTempFolder.getInstance();
+  private static final String TMP_FILE_PREFIX = "tmp-";
+  private DistributedFSShuffleFile commitTarget = null;
+  private UUID uuid = null;
+
+  //Taken from Spark UnsafeShuffleWriter
+  private static class CloseAndFlushShieldOutputStream extends CloseShieldOutputStream {
+
+    CloseAndFlushShieldOutputStream(OutputStream outputStream) {
+      super(outputStream);
+    }
+
+    @Override
+    public void flush() {
+      // do nothing
+    }
+  }
+
+  private DistributedFSTmpShuffleFile(String path) {
+    super(path);
+  }
+
+  static DistributedFSTmpShuffleFile make() {
+    val uuid = UUID.randomUUID();
+    val tmpPath = folder.getTmpPath();
+    val filename = String.format("%s%s", TMP_FILE_PREFIX, uuid.toString());
+    val fullPath = new Path(String.format("%s/%s", tmpPath, filename));
+
+    val ret = new DistributedFSTmpShuffleFile(fullPath.toString());
+    ret.uuid = uuid;
+    return ret;
+  }
+
+  static DistributedFSTmpShuffleFile make(ShuffleFile file) throws IOException {
+    if (file == null) {
+      throw new IOException("file is null");
+    }
+    if (!(file instanceof DistributedFSShuffleFile)) {
+      throw new IOException("only accept DistributedFSShuffleFile");
+    }
+    val ret = make();
+    ret.commitTarget = (DistributedFSShuffleFile) file;
+    return ret;
+  }
+
+  @Override
+  public TmpShuffleFile create() throws IOException {
+    val fileContext = getFileContext();
+    if (fileContext.util().exists(underlyingFilePath)) {
+      val deleted = fileContext.delete(underlyingFilePath, true);
+      log.info("file already exists.  delete file {} (result: {})",
+        underlyingFilePath.toString(), deleted);
+    }
+    val createFlags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
+    val createdStream = fileContext.create(underlyingFilePath, createFlags, Options.CreateOpts.createParent());
+    if (createdStream == null) {
+      throw new IOException(String.format("file %s already exists.", getPath()));
+    } else {
+      createdStream.close();
+      log.debug("file {} created.", getPath());
+    }
+    return this;
+  }
+
+  @Override
+  public void swap(TmpShuffleFile other) throws IOException {
+    if (!other.exists()) {
+      val message = "Can only swap with a uncommitted tmp file";
+      throw new IOException(message);
+    }
+
+    val otherFile = (DistributedFSTmpShuffleFile) other;
+
+    delete();
+
+    val tmpUuid = otherFile.uuid;
+    otherFile.uuid = this.uuid;
+    this.uuid = tmpUuid;
+
+    val tmpFilePath = this.underlyingFilePath;
+    this.underlyingFilePath = otherFile.underlyingFilePath;
+    otherFile.underlyingFilePath = tmpFilePath;
+  }
+
+  @Override
+  public DistributedFSShuffleFile getCommitTarget() {
+    return this.commitTarget;
+  }
+
+  @Override
+  public ShuffleFile commit() throws IOException {
+    if (commitTarget == null) {
+      throw new IOException("No commit target.");
+    } else if (!exists()) {
+      create();
+    }
+    if (commitTarget.exists()) {
+      val msg = String.format("commit target %s already exists", commitTarget.getPath());
+      log.warn(msg);
+      throw new FileAlreadyExistsException(msg);
+    }
+    log.debug("commit tmp file {} to target file {}.",
+      getPath(), getCommitTarget().getPath());
+
+    rename(commitTarget.getPath());
+    return commitTarget;
+  }
+
+  @Override
+  public void recall() {
+    val commitTarget = getCommitTarget();
+    if (commitTarget != null) {
+      log.info("recall tmp file {} of target file {}.",
+        getPath(), commitTarget.getPath());
+    } else {
+      log.info("recall tmp file {} without target file.", getPath());
+    }
+
+    try {
+      delete();
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Override
+  public UUID uuid() {
+    return this.uuid;
+  }
+
+  @Override
+  public OutputStream makeOutputStream() {
+    val fileContext = getFileContext();
+    val createFlags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
+    OutputStream ret;
+    try {
+      ret = fileContext.create(underlyingFilePath, createFlags, Options.CreateOpts.createParent());
+      log.debug("create output stream for {}.", getPath());
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+    return ret;
+  }
+
+  @Override
+  public int getBufferSize() {
+    val fileContext = getFileContext();
+    try {
+      return Long.valueOf(fileContext.getFileStatus(underlyingFilePath).getLen()).intValue();
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Override
+  public long[] fastMerge(ShuffleSpillInfo[] spills) throws IOException {
+    assert (spills.length >= 2);
+    val numPartitions = spills[0].partitionLengths().length;
+    val partitionLengths = new long[numPartitions];
+    val spillInputStreams = new InputStream[spills.length];
+
+    val fileContext = getFileContext();
+    val createFlags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
+    val bos = fileContext.create(underlyingFilePath, createFlags, Options.CreateOpts.createParent());
+    // Use a counting output stream to avoid having to close the underlying file and ask
+    // the file system for its size after each partition is written.
+    val mergedFileOutputStream = new CountingOutputStream(bos);
+
+    boolean threwException = true;
+    try {
+      for (int i = 0; i < spills.length; i++) {
+        val shuffleTmpFile = (DistributedFSTmpShuffleFile) spills[i].file();
+        spillInputStreams[i] = fileContext.open(shuffleTmpFile.underlyingFilePath);
+      }
+
+      for (int partition = 0; partition < numPartitions; partition++) {
+        final long initialFileLength = mergedFileOutputStream.getByteCount();
+        // Shield the underlying output stream from close() and flush() calls, so that we can close
+        // the higher level streams to make sure all data is really flushed and internal state is
+        // cleaned.
+        val partitionOutput = new CloseAndFlushShieldOutputStream(mergedFileOutputStream);
+        for (int i = 0; i < spills.length; i++) {
+          val partitionLengthInSpill = spills[i].partitionLengths()[partition];
+          if (partitionLengthInSpill > 0) {
+            try (InputStream partitionInputStream = new LimitedInputStream(spillInputStreams[i],
+              partitionLengthInSpill, false)) {
+              ByteStreams.copy(partitionInputStream, partitionOutput);
+            }
+          }
+        }
+        partitionOutput.flush();
+        partitionOutput.close();
+        partitionLengths[partition] = (mergedFileOutputStream.getByteCount() - initialFileLength);
+      }
+      threwException = false;
+    } finally {
+      // To avoid masking exceptions that caused us to prematurely enter the finally block, only
+      // throw exceptions during cleanup if threwException == false.
+      for (InputStream stream: spillInputStreams) {
+        Closeables.close(stream, threwException);
+      }
+      Closeables.close(mergedFileOutputStream, threwException);
+    }
+    return partitionLengths;
+  }
+}

--- a/src/main/java/com/memverge/splash/dfs/FileContextManager.java
+++ b/src/main/java/com/memverge/splash/dfs/FileContextManager.java
@@ -1,0 +1,52 @@
+package com.memverge.splash.dfs;
+
+import lombok.val;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.UnsupportedFileSystemException;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.SplashOpts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+
+class FileContextManager {
+  private static final Logger log = LoggerFactory.getLogger(FileContextManager.class);
+  private static final ConcurrentHashMap<Configuration, FileContext> contextMap = new ConcurrentHashMap<>();
+  private static final Configuration hadoopConf = new Configuration();
+
+  static {
+    val sparkConf = Optional
+      .ofNullable(SparkEnv.get())
+      .map(SparkEnv::conf)
+      .orElse(new SparkConf(false));
+    val splashFolder = sparkConf
+      .get(SplashOpts.localSplashFolder().key(), hadoopConf.get(FS_DEFAULT_NAME_KEY, FS_DEFAULT_NAME_DEFAULT));
+    hadoopConf.set(FS_DEFAULT_NAME_KEY, splashFolder);
+  }
+
+  static FileContext getOrCreate(Configuration conf) {
+    log.info("Creating file context for {}", conf.get(FS_DEFAULT_NAME_KEY));
+    return contextMap.computeIfAbsent(conf, k -> {
+      try {
+        return FileContext.getFileContext(conf);
+      } catch (UnsupportedFileSystemException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  static FileContext getOrCreate() {
+    return getOrCreate(hadoopConf);
+  }
+
+  static Configuration getHadoopConf() {
+    return hadoopConf;
+  }
+}

--- a/src/test/resources/spark-version-info.properties
+++ b/src/test/resources/spark-version-info.properties
@@ -1,6 +1,0 @@
-version=
-user=
-revision=
-branch=
-date=
-url=


### PR DESCRIPTION
This PR adds support for any HDFS compliant file system. The code has been tested with unit tests and `ShufflePerfTool`. Here is the output.
```
java -cp target/splash-0.8.0-shaded.jar com.memverge.splash.ShufflePerfTool -f com.memverge.splash.dfs.DistributedFSFactory -d 64 -m 200 -r 200 -t 8 -o
overwrite, removing existing shuffle for shuffleTest-1
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/Users/achawade/workspace/splash/target/splash-0.8.0-shaded.jar) to method java.nio.Bits.unaligned()
WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
log4j:WARN No appenders could be found for logger (org.apache.htrace.core.Tracer).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
==========================================
Writing 200 shuffle with 8 threads: 100%            (200/200)
Write shuffle data completed in 11082 milliseconds
    Reading index file:  0 ms
    Reading data file:   0 ms
    storage factory:     com.memverge.splash.dfs.DistributedFSFactory
    shuffle folder:      /var/folders/5n/6p64xp817jg_z4pjq1xqv8pr0000gn/T/achawade/splash/shuffleTest-1/shuffle
    number of mappers:   200
    number of reducers:  200
    total shuffle size:  3.13GB
    bytes written:       3.13GB
    bytes read:          0.0B
    number of blocks:    64
    blocks size:         256.00KB
    partition size:      81.92KB
    concurrent tasks:    8
    bandwidth:           288.76MB/s

==========================================
Reading 40000 partitions with 8 threads: 100%        (40000/40000)
Read shuffle data completed in 3360 milliseconds
    Reading index file:  19817 ms
    Reading data file:   6040 ms
    storage factory:     com.memverge.splash.dfs.DistributedFSFactory
    shuffle folder:      /var/folders/5n/6p64xp817jg_z4pjq1xqv8pr0000gn/T/achawade/splash/shuffleTest-1/shuffle
    number of mappers:   200
    number of reducers:  200
    total shuffle size:  3.13GB
    bytes written:       3.13GB
    bytes read:          3.12GB
    number of blocks:    64
    blocks size:         256.00KB
    partition size:      81.92KB
    concurrent tasks:    8
    bandwidth:           952.38MB/s

```